### PR TITLE
PMTCT stop saving user account to identity

### DIFF
--- a/go-app-ussd_pmtct.js
+++ b/go-app-ussd_pmtct.js
@@ -397,7 +397,7 @@ go.app = function() {
                                     self.im.user.set_answer("edd", contacts[0].extra.edd || null);
                                     self.im.user.set_answer("subscription_type", subscription_type);
                                     self.im.user.set_answer("vumi_user_account", contacts[0].user_account);
-                                    self.im.user.set_answer("vumi_contact_key", contacts[0].contact_key);
+                                    self.im.user.set_answer("vumi_contact_key", contacts[0].key);
 
                                     return self.im.user
                                     .set_lang(self.im.user.answers.lang_code)
@@ -545,7 +545,6 @@ go.app = function() {
             var identity_info = self.im.user.answers.identity;
             identity_info.details.mom_dob = self.im.user.answers.mom_dob;
             identity_info.details.lang_code = self.im.user.answers.lang_code;
-            identity_info.details.vumi_user_account = self.im.user.answers.vumi_user_account;
             identity_info.details.vumi_contact_key = self.im.user.answers.vumi_contact_key;
             identity_info.details.source = "pmtct";
 

--- a/src/ussd_pmtct.js
+++ b/src/ussd_pmtct.js
@@ -394,7 +394,7 @@ go.app = function() {
                                     self.im.user.set_answer("edd", contacts[0].extra.edd || null);
                                     self.im.user.set_answer("subscription_type", subscription_type);
                                     self.im.user.set_answer("vumi_user_account", contacts[0].user_account);
-                                    self.im.user.set_answer("vumi_contact_key", contacts[0].contact_key);
+                                    self.im.user.set_answer("vumi_contact_key", contacts[0].key);
 
                                     return self.im.user
                                     .set_lang(self.im.user.answers.lang_code)
@@ -542,7 +542,6 @@ go.app = function() {
             var identity_info = self.im.user.answers.identity;
             identity_info.details.mom_dob = self.im.user.answers.mom_dob;
             identity_info.details.lang_code = self.im.user.answers.lang_code;
-            identity_info.details.vumi_user_account = self.im.user.answers.vumi_user_account;
             identity_info.details.vumi_contact_key = self.im.user.answers.vumi_contact_key;
             identity_info.details.source = "pmtct";
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1970,7 +1970,7 @@ module.exports = function() {
                         },
                         "mom_dob": "1982-02-01",
                         "lang_code": "eng_ZA",
-                        "vumi_user_account": "1aa0dea2f82945a48cc258c61d756f16",
+                        "vumi_contact_key":"3e99804c1f1c4c9790517923bb8b318b",
                         "source": "pmtct"
                     },
                     "created_at": "2016-07-17T06:13:29.693272Z",
@@ -1997,7 +1997,7 @@ module.exports = function() {
                         },
                         "mom_dob": "1954-05-29",
                         "lang_code": "eng_ZA",
-                        "vumi_user_account": "1aa0dea2f82945a48cc258c61d756f16",
+                        "vumi_contact_key":"3e99804c1f1c4c9790517923bb8b318b",
                         "source": "pmtct"
                     },
                     "created_at": "2016-07-17T06:13:29.693272Z",
@@ -2025,7 +2025,7 @@ module.exports = function() {
                         },
                         "mom_dob": "1975-09-23",
                         "lang_code": "zul_ZA",
-                        "vumi_user_account": "1aa0dea2f82945a48cc258c61d756f16",
+                        "vumi_contact_key":"3e99804c1f1c4c9790517923bb8b318b",
                         "source": "pmtct"
                     },
                     "created_at": "2016-07-17T06:13:29.693272Z",
@@ -2053,7 +2053,7 @@ module.exports = function() {
                         },
                         "mom_dob": "1981-04-26",
                         "lang_code": "eng_ZA",
-                        "vumi_user_account": "1aa0dea2f82945a48cc258c61d756f16",
+                        "vumi_contact_key":"3e99804c1f1c4c9790517923bb8b318b",
                         "source": "pmtct"
                     },
                     "created_at": "2016-07-17T06:13:29.693272Z",


### PR DESCRIPTION
We should only be saving the contact key - the user account is the essentially MomConnect's account number.
