### PR TITLE
PMTCT - fix get_january call

### DIFF
--- a/go-app-ussd_pmtct.js
+++ b/go-app-ussd_pmtct.js
@@ -542,7 +542,7 @@ go.app = function() {
             return new ChoiceState(name, {
                 question: $("In which month were you born?"),
                 choices: utils.make_month_choices(
-                    $, get_january(self.im.config.testing_today), 12, 1, "MM", "MMM"),
+                    $, utils.get_january(self.im.config.testing_today), 12, 1, "MM", "MMM"),
                 next: function(choice) {
                     self.im.user.set_answer("dob_month", choice.value);
                     return "state_birth_day";

--- a/src/ussd_pmtct.js
+++ b/src/ussd_pmtct.js
@@ -539,7 +539,7 @@ go.app = function() {
             return new ChoiceState(name, {
                 question: $("In which month were you born?"),
                 choices: utils.make_month_choices(
-                    $, get_january(self.im.config.testing_today), 12, 1, "MM", "MMM"),
+                    $, utils.get_january(self.im.config.testing_today), 12, 1, "MM", "MMM"),
                 next: function(choice) {
                     self.im.user.set_answer("dob_month", choice.value);
                     return "state_birth_day";


### PR DESCRIPTION
a `make_month_choices` call inside `state_birth_month` is being made.
As one of `make_month_choices` arguments, do a `utils.get_january` call instead of the current `get_january`

Things seem to work anyway, but think it's better to be more clear in calling `get_january`
