### PR TITLE
Fix sending edd for pmtct registration

### DIFF
--- a/go-app-ussd_pmtct_seed.js
+++ b/go-app-ussd_pmtct_seed.js
@@ -354,7 +354,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "baby_dob": self.im.user.answers.identity.last_baby_dob,
+                            "baby_dob": self.im.user.answers.identity.details.last_baby_dob,
                         }
                     };
 
@@ -366,7 +366,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "edd": self.im.user.answers.identity.last_edd
+                            "edd": self.im.user.answers.identity.details.last_edd
                         }
                     };
                 }

--- a/src/ussd_pmtct_seed.js
+++ b/src/ussd_pmtct_seed.js
@@ -351,7 +351,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "baby_dob": self.im.user.answers.identity.last_baby_dob,
+                            "baby_dob": self.im.user.answers.identity.details.last_baby_dob,
                         }
                     };
 
@@ -363,7 +363,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "edd": self.im.user.answers.identity.last_edd
+                            "edd": self.im.user.answers.identity.details.last_edd
                         }
                     };
                 }

--- a/test/fixtures_hub.js
+++ b/test/fixtures_hub.js
@@ -673,7 +673,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000001",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "edd": "2017-05-28"
                     }
                 }
             },
@@ -691,7 +692,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000002",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "edd": "2017-05-27"
                     }
                 }
             },
@@ -709,7 +711,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000003",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "baby_dob": "2017-05-27"
                     }
                 }
             },
@@ -727,7 +730,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000004",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "baby_dob": "2017-05-27"
                     }
                 }
             },

--- a/test/fixtures_identity_store.js
+++ b/test/fixtures_identity_store.js
@@ -1168,6 +1168,7 @@ module.exports = function() {
                                     "+27820000111": {}
                                 }
                             },
+                            "last_edd": "2017-05-28"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1208,7 +1209,8 @@ module.exports = function() {
                                     "+27820000222": {}
                                 }
                             },
-                            "consent": true
+                            "consent": true,
+                            "last_edd": "2017-05-27"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1249,7 +1251,8 @@ module.exports = function() {
                                     "+27820000333": {}
                                 }
                             },
-                            "mom_dob": "1981-04-26"
+                            "mom_dob": "1981-04-26",
+                            "last_baby_dob": "2017-05-27"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1291,7 +1294,8 @@ module.exports = function() {
                                 }
                             },
                             "consent": true,
-                            "mom_dob": "1981-04-26"
+                            "mom_dob": "1981-04-26",
+                            "last_baby_dob": "2017-05-27"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1362,6 +1366,7 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
+                        "last_edd": "2017-05-28"
                     },
                     "created_at":"2016-06-21T06:13:29.693272Z",
                     "updated_at":"2016-06-21T06:13:29.693298Z"
@@ -1392,6 +1397,7 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
+                        "last_edd": "2017-05-27"
                     },
                     "created_at":"2016-06-21T06:13:29.693272Z",
                     "updated_at":"2016-06-21T06:13:29.693298Z"
@@ -1422,6 +1428,7 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
+                        "last_baby_dob": "2017-05-27"
                     },
                     "created_at": "2016-06-21T06:13:29.693272Z",
                     "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1452,6 +1459,7 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
+                        "last_baby_dob": "2017-05-27"
                     },
                     "created_at": "2016-06-21T06:13:29.693272Z",
                     "updated_at": "2016-06-21T06:13:29.693298Z"

--- a/test/fixtures_pmtct.js
+++ b/test/fixtures_pmtct.js
@@ -133,7 +133,8 @@ module.exports = function() {
                                     "+27820000333": {}
                                 }
                             },
-                            "mom_dob": "1981-04-26"
+                            "mom_dob": "1981-04-26",
+                            "last_baby_dob": "2017-05-27"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -175,7 +176,8 @@ module.exports = function() {
                                 }
                             },
                             "consent": true,
-                            "mom_dob": "1981-04-26"
+                            "mom_dob": "1981-04-26",
+                            "last_baby_dob": "2017-05-27"
                         },
                         "created_at": "2016-06-21T06:13:29.693272Z",
                         "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -1974,7 +1976,8 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
-                        "source": "pmtct"
+                        "source": "pmtct",
+                        "last_baby_dob": "2017-05-27"
                     },
                     "created_at": "2016-06-21T06:13:29.693272Z",
                     "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -2005,7 +2008,8 @@ module.exports = function() {
                         "pmtct": {
                             "lang_code": "eng_ZA"
                         },
-                        "source": "pmtct"
+                        "source": "pmtct",
+                        "last_baby_dob": "2017-05-27"
                     },
                     "created_at": "2016-06-21T06:13:29.693272Z",
                     "updated_at": "2016-06-21T06:13:29.693298Z"
@@ -3047,7 +3051,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000001",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "edd": "2017-05-28"
                     }
                 }
             },
@@ -3065,7 +3070,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000002",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "edd": "2017-05-28"
                     }
                 }
             },
@@ -3113,7 +3119,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000003",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "baby_dob": "2017-05-28"
                     }
                 }
             },
@@ -3161,7 +3168,8 @@ module.exports = function() {
                     "data": {
                         "operator_id": "cb245673-aa41-4302-ac47-00000000004",
                         "mom_dob": "1981-04-26",
-                        "language": "eng_ZA"
+                        "language": "eng_ZA",
+                        "baby_dob": "2017-05-27"
                     }
                 }
             },


### PR DESCRIPTION
At the moment, the app is looking at `identity.last_edd` for the edd date, when it is actually being stored at `identity.details.last_edd`. We should change it to look there, and change the tests to actually check that it is sending the correct information to the registration service.