### PR TITLE
Add Ngwana to baby switch words

### DIFF
--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -138,7 +138,7 @@ go.app = function() {
                                     return self.states.create("state_opt_in_enter");
                                 case "BABY": case "USANA": case "SANA": case "BABA":
                                 case "BABBY": case "LESEA": case "BBY": case "BABYA":
-                                case "OBABY":
+                                case "OBABY": case "NGWANA":
                                     return self.states.create("state_baby_enter");
                                 default: // Logs a support ticket
                                     return self.states.create("state_default_enter");

--- a/test/sms_inbound.test.js
+++ b/test/sms_inbound.test.js
@@ -505,6 +505,21 @@ describe("app", function() {
                     })
                     .run();
             });
+            it("using 'baby' keyword 'ngwana'", function() {
+                return tester
+                    .setup.user.addr('27820001002')
+                    .inputs('Ngwana has been born, bub')
+                    .check.interaction({
+                        state: 'state_baby',
+                        reply:
+                            'Thank you. You will now receive messages related to newborn babies. ' +
+                            'If you have any medical concerns please visit your nearest clinic'
+                    })
+                    .check(function(api) {
+                        utils.check_fixtures_used(api, [16, 51, 54, 181]);
+                    })
+                    .run();
+            });
         });
     });
 });


### PR DESCRIPTION
'Ngwana' seems to mean "baby" or "child" in Northern Sotho (Sepedi). It's something that we see quite a lot and that the helpdesk operators use as an indication that the user wants to change to the post_birth message set.