### PR TITLE
Allow channel to be set per message.

### DIFF
--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -246,6 +246,19 @@ go.app = function() {
             });
         };
 
+        self.get_channel = function() {
+            return sbm
+                .is_identity_subscribed(self.im.user.answers.registrant.id, [/whatsapp/])
+                .then(function(confirmed) {
+                    if(confirmed) {
+                        var pilot_config = self.im.config.pilot || {};
+                        return pilot_config.channel;
+                    } else {
+                        return self.im.config.services.message_sender.channel;
+                    }
+                });
+        };
+
         self.attach_session_length_helper = function(im) {
             // If we have transport metadata then attach the session length
             // helper to this app
@@ -314,16 +327,23 @@ go.app = function() {
         };
 
         self.send_redial_sms = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please dial back in to {{ USSD_number }} to complete the pregnancy registration."
-                ).context({
-                    USSD_number: self.im.config.channel
-                }))
-            );
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please dial back in to {{ USSD_number }} to complete the pregnancy registration."
+                            ).context({
+                                USSD_number: self.im.config.channel
+                            })),
+                            {
+                                channel: channel
+                            }
+                        );
+                });
         };
 
         self.number_opted_out = function(identity, msisdn) {
@@ -378,42 +398,57 @@ go.app = function() {
             return registration_info;
         };
 
-        self.send_registration_thanks = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
-                    "You can register for the full set of FREE helpful messages at a clinic."
-                ))
-            );
+        self.send_registration_thanks = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
+                                "You can register for the full set of FREE helpful messages at a clinic."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
-        self.send_compliment_instructions = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please reply to this message with your compliment. If it " +
-                    "relates to the service at the clinic, include the clinic or " +
-                    "clinic worker name. Standard rates apply."
-                ))
-            );
+        self.send_compliment_instructions = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please reply to this message with your compliment. If it " +
+                                "relates to the service at the clinic, include the clinic or " +
+                                "clinic worker name. Standard rates apply."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
-        self.send_complaint_instructions = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please reply to this message with your complaint. If it " +
-                    "relates to the service at the clinic, include the clinic or " +
-                    "clinic worker name. Standard rates apply."
-                ))
-            );
+        self.send_complaint_instructions = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please reply to this message with your complaint. If it " +
+                                "relates to the service at the clinic, include the clinic or " +
+                                "clinic worker name. Standard rates apply."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
         self.add = function(name, creator) {
@@ -466,7 +501,10 @@ go.app = function() {
                     .set_lang(self.im.user.answers.registrant.details.lang_code)
                     .then(function() {
                         return sbm
-                        .check_identity_subscribed(self.im.user.answers.registrant.id, "momconnect")
+                        .is_identity_subscribed(self.im.user.answers.registrant.id, [
+                            /^momconnect/,
+                            /^whatsapp/,
+                        ])
                         .then(function(identity_subscribed_to_momconnect) {
                             if (identity_subscribed_to_momconnect) {
                                 return self.states.create('state_registered_full');
@@ -687,7 +725,9 @@ go.app = function() {
             return Q.all([
                 is.update_identity(self.im.user.answers.registrant.id, registrant_info),
                 hub.create_registration(registration_info),
-                self.send_registration_thanks()
+                self.send_registration_thanks({
+                    channel: self.get_channel(self.im)
+                })
             ])
             .then(function() {
                 return self.states.create('state_end_success');
@@ -717,13 +757,17 @@ go.app = function() {
                 next: function(choice) {
                     if (choice.value === "compliment") {
                         return self
-                        .send_compliment_instructions()
+                        .send_compliment_instructions({
+                            channel: self.get_channel(self.im)
+                        })
                         .then(function() {
                             return 'state_end_compliment';
                         });
                     } else if (choice.value === "complaint") {
                         return self
-                        .send_complaint_instructions()
+                        .send_complaint_instructions({
+                            channel: self.get_channel(self.im)
+                        })
                         .then(function() {
                             return 'state_end_complaint';
                         });

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -398,7 +398,7 @@ go.app = function() {
             return registration_info;
         };
 
-        self.send_registration_thanks = function(channel) {
+        self.send_registration_thanks = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -409,13 +409,13 @@ go.app = function() {
                             self.im.user.i18n($(
                                 "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
                                 "You can register for the full set of FREE helpful messages at a clinic."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
-        self.send_compliment_instructions = function(channel) {
+        self.send_compliment_instructions = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -427,13 +427,13 @@ go.app = function() {
                                 "Please reply to this message with your compliment. If it " +
                                 "relates to the service at the clinic, include the clinic or " +
                                 "clinic worker name. Standard rates apply."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
-        self.send_complaint_instructions = function(channel) {
+        self.send_complaint_instructions = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -445,9 +445,9 @@ go.app = function() {
                                 "Please reply to this message with your complaint. If it " +
                                 "relates to the service at the clinic, include the clinic or " +
                                 "clinic worker name. Standard rates apply."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
@@ -725,9 +725,7 @@ go.app = function() {
             return Q.all([
                 is.update_identity(self.im.user.answers.registrant.id, registrant_info),
                 hub.create_registration(registration_info),
-                self.send_registration_thanks({
-                    channel: self.get_channel(self.im)
-                })
+                self.send_registration_thanks()
             ])
             .then(function() {
                 return self.states.create('state_end_success');
@@ -757,17 +755,13 @@ go.app = function() {
                 next: function(choice) {
                     if (choice.value === "compliment") {
                         return self
-                        .send_compliment_instructions({
-                            channel: self.get_channel(self.im)
-                        })
+                        .send_compliment_instructions()
                         .then(function() {
                             return 'state_end_compliment';
                         });
                     } else if (choice.value === "complaint") {
                         return self
-                        .send_complaint_instructions({
-                            channel: self.get_channel(self.im)
-                        })
+                        .send_complaint_instructions()
                         .then(function() {
                             return 'state_end_complaint';
                         });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/praekeltfoundation/ndoh-jsbox",
   "dependencies": {
     "vumigo_v02": "~0.2",
-    "seed-jsbox-utils": "~0.1.16",
+    "seed-jsbox-utils": "~0.1.17",
     "lodash": "~2.4.1",
     "q": "~0.9.7",
     "moment": "~2.6",

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -96,6 +96,19 @@ go.app = function() {
             });
         };
 
+        self.get_channel = function() {
+            return sbm
+                .is_identity_subscribed(self.im.user.answers.registrant.id, [/whatsapp/])
+                .then(function(confirmed) {
+                    if(confirmed) {
+                        var pilot_config = self.im.config.pilot || {};
+                        return pilot_config.channel;
+                    } else {
+                        return self.im.config.services.message_sender.channel;
+                    }
+                });
+        };
+
         self.attach_session_length_helper = function(im) {
             // If we have transport metadata then attach the session length
             // helper to this app
@@ -164,16 +177,23 @@ go.app = function() {
         };
 
         self.send_redial_sms = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please dial back in to {{ USSD_number }} to complete the pregnancy registration."
-                ).context({
-                    USSD_number: self.im.config.channel
-                }))
-            );
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please dial back in to {{ USSD_number }} to complete the pregnancy registration."
+                            ).context({
+                                USSD_number: self.im.config.channel
+                            })),
+                            {
+                                channel: channel
+                            }
+                        );
+                });
         };
 
         self.number_opted_out = function(identity, msisdn) {
@@ -228,42 +248,57 @@ go.app = function() {
             return registration_info;
         };
 
-        self.send_registration_thanks = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
-                    "You can register for the full set of FREE helpful messages at a clinic."
-                ))
-            );
+        self.send_registration_thanks = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
+                                "You can register for the full set of FREE helpful messages at a clinic."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
-        self.send_compliment_instructions = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please reply to this message with your compliment. If it " +
-                    "relates to the service at the clinic, include the clinic or " +
-                    "clinic worker name. Standard rates apply."
-                ))
-            );
+        self.send_compliment_instructions = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please reply to this message with your compliment. If it " +
+                                "relates to the service at the clinic, include the clinic or " +
+                                "clinic worker name. Standard rates apply."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
-        self.send_complaint_instructions = function() {
-            return ms.
-            create_outbound_message(
-                self.im.user.answers.registrant.id,
-                self.im.user.answers.registrant_msisdn,
-                self.im.user.i18n($(
-                    "Please reply to this message with your complaint. If it " +
-                    "relates to the service at the clinic, include the clinic or " +
-                    "clinic worker name. Standard rates apply."
-                ))
-            );
+        self.send_complaint_instructions = function(channel) {
+            return self
+                .get_channel()
+                .then(function(channel) {
+                    return ms.
+                        create_outbound(
+                            self.im.user.answers.registrant.id,
+                            self.im.user.answers.registrant_msisdn,
+                            self.im.user.i18n($(
+                                "Please reply to this message with your complaint. If it " +
+                                "relates to the service at the clinic, include the clinic or " +
+                                "clinic worker name. Standard rates apply."
+                            ), {
+                                channel: channel
+                            }));
+                });
         };
 
         self.add = function(name, creator) {
@@ -316,7 +351,10 @@ go.app = function() {
                     .set_lang(self.im.user.answers.registrant.details.lang_code)
                     .then(function() {
                         return sbm
-                        .check_identity_subscribed(self.im.user.answers.registrant.id, "momconnect")
+                        .is_identity_subscribed(self.im.user.answers.registrant.id, [
+                            /^momconnect/,
+                            /^whatsapp/,
+                        ])
                         .then(function(identity_subscribed_to_momconnect) {
                             if (identity_subscribed_to_momconnect) {
                                 return self.states.create('state_registered_full');
@@ -537,7 +575,9 @@ go.app = function() {
             return Q.all([
                 is.update_identity(self.im.user.answers.registrant.id, registrant_info),
                 hub.create_registration(registration_info),
-                self.send_registration_thanks()
+                self.send_registration_thanks({
+                    channel: self.get_channel(self.im)
+                })
             ])
             .then(function() {
                 return self.states.create('state_end_success');
@@ -567,13 +607,17 @@ go.app = function() {
                 next: function(choice) {
                     if (choice.value === "compliment") {
                         return self
-                        .send_compliment_instructions()
+                        .send_compliment_instructions({
+                            channel: self.get_channel(self.im)
+                        })
                         .then(function() {
                             return 'state_end_compliment';
                         });
                     } else if (choice.value === "complaint") {
                         return self
-                        .send_complaint_instructions()
+                        .send_complaint_instructions({
+                            channel: self.get_channel(self.im)
+                        })
                         .then(function() {
                             return 'state_end_complaint';
                         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -248,7 +248,7 @@ go.app = function() {
             return registration_info;
         };
 
-        self.send_registration_thanks = function(channel) {
+        self.send_registration_thanks = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -259,13 +259,13 @@ go.app = function() {
                             self.im.user.i18n($(
                                 "Congratulations on your pregnancy. You will now get free SMSs about MomConnect. " +
                                 "You can register for the full set of FREE helpful messages at a clinic."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
-        self.send_compliment_instructions = function(channel) {
+        self.send_compliment_instructions = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -277,13 +277,13 @@ go.app = function() {
                                 "Please reply to this message with your compliment. If it " +
                                 "relates to the service at the clinic, include the clinic or " +
                                 "clinic worker name. Standard rates apply."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
-        self.send_complaint_instructions = function(channel) {
+        self.send_complaint_instructions = function() {
             return self
                 .get_channel()
                 .then(function(channel) {
@@ -295,9 +295,9 @@ go.app = function() {
                                 "Please reply to this message with your complaint. If it " +
                                 "relates to the service at the clinic, include the clinic or " +
                                 "clinic worker name. Standard rates apply."
-                            ), {
+                            )), {
                                 channel: channel
-                            }));
+                            });
                 });
         };
 
@@ -575,9 +575,7 @@ go.app = function() {
             return Q.all([
                 is.update_identity(self.im.user.answers.registrant.id, registrant_info),
                 hub.create_registration(registration_info),
-                self.send_registration_thanks({
-                    channel: self.get_channel(self.im)
-                })
+                self.send_registration_thanks()
             ])
             .then(function() {
                 return self.states.create('state_end_success');
@@ -607,17 +605,13 @@ go.app = function() {
                 next: function(choice) {
                     if (choice.value === "compliment") {
                         return self
-                        .send_compliment_instructions({
-                            channel: self.get_channel(self.im)
-                        })
+                        .send_compliment_instructions()
                         .then(function() {
                             return 'state_end_compliment';
                         });
                     } else if (choice.value === "complaint") {
                         return self
-                        .send_complaint_instructions({
-                            channel: self.get_channel(self.im)
-                        })
+                        .send_complaint_instructions()
                         .then(function() {
                             return 'state_end_complaint';
                         });

--- a/test/fixtures_pilot.js
+++ b/test/fixtures_pilot.js
@@ -62,8 +62,6 @@ module.exports = function() {
             }
         },
         post_outbound_message: function(params) {
-            // defaulting to this identity + address as its used in many
-            // fixtures
             params = params || {};
             var identity = params.identity;
             var address = params.address;

--- a/test/fixtures_pilot.js
+++ b/test/fixtures_pilot.js
@@ -2,7 +2,6 @@ module.exports = function() {
     _ = require('lodash');
     function make_check_fixture(address, exists) {
         return {
-            'key': 'pilot.check.+' + address,
             'repeatable': true,
             'request': {
                 'method': 'GET',
@@ -35,15 +34,12 @@ module.exports = function() {
         not_exists: function(address) {
             return make_check_fixture(address, false);
         },
-        registration: function(params) {
-            // defaulting to this identity + address as its used in many
-            // fixtures
-            var identity = params.identity || 'cb245673-aa41-4302-ac47-00000001001';
-            var address = params.address || '27820001001';
+        post_registration: function(params) {
+            var identity = params.identity;
+            var address = params.address;
             var language = params.language || 'zul_ZA';
             var reg_type = params.reg_type || 'momconnect_prebirth';
             return {
-                "key": "post.hub.register.identity." + identity,
                 "request": {
                     "url": 'http://hub/api/v1/registration/',
                     "method": 'POST',
@@ -64,6 +60,81 @@ module.exports = function() {
                     "data": {}
                 }
             }
-        }
+        },
+        post_outbound_message: function(params) {
+            // defaulting to this identity + address as its used in many
+            // fixtures
+            params = params || {};
+            var identity = params.identity;
+            var address = params.address;
+            var content = params.content || 'default content';
+            var metadata = params.metadata || {};
+            var channel = params.channel;
+
+            return {
+                "request": {
+                    "url": 'http://ms/api/v1/outbound/',
+                    "method": 'POST',
+                    "data": {
+                        "to_identity": identity,
+                        "to_addr": address,
+                        "content": content,
+                        "metadata": metadata,
+                        "channel": channel
+                    }
+                },
+                "response": {
+                    "code": 201,
+                    "data": {}
+                }
+            };
+        },
+
+        subscribe_id_to: function(params) {
+            params = params || {};
+            identity = params.identity || 'cb245673-aa41-4302-ac47-00000001001';
+            messagesets = params.messagesets || [];
+            language = params.language || 'eng_ZA';
+
+            return {
+                "repeatable": true,
+                "request": {
+                    "url": 'http://sbm/api/v1/subscriptions/',
+                    "method": 'GET',
+                    "params": {
+                        "identity": identity,
+                        "active": 'True'
+                    }
+                },
+                "response": {
+                    "code": 200,
+                    "data": {
+                        "count": messagesets.length,
+                        "next": null,
+                        "previous": null,
+                        "results": _.map(messagesets, function(messageset) {
+                            return {
+                                'url': 'http://sbm/api/v1/subscriptions/51fcca25-2e85-4c44-subscription-1005',
+                                'id': '51fcca25-2e85-4c44-subscription-1005',
+                                'version': 1,
+                                'identity': identity,
+                                'messageset': messageset,
+                                'next_sequence_number': 1,
+                                'lang': language,
+                                'active': true,
+                                'completed': false,
+                                'schedule': 1,
+                                'process_status': 0,
+                                'metadata': {},
+                                'created_at': "2016-08-12T06:13:29.693272Z",
+                                'updated_at': "2016-08-12T06:13:29.693272Z"
+                            }
+                        })
+                    }
+                }
+            };
+        },
+
+        "silly": "javascript commas"
     }
 }

--- a/test/fixtures_stage_based_messaging.js
+++ b/test/fixtures_stage_based_messaging.js
@@ -349,6 +349,16 @@ module.exports = function() {
                             "content_type": 'text',
                             "created_at": '2016-06-22T06:13:29.693272Z',
                             "updated_at": '2016-06-22T06:13:29.693272Z'
+                        },
+                        {
+                            "id": 62,
+                            "short_name": 'whatsapp_prebirth.patient.1',
+                            "notes": null,
+                            "next_set": null,  // inaccurate
+                            "default_schedule": 111,
+                            "content_type": 'text',
+                            "created_at": '2016-06-22T06:13:29.693272Z',
+                            "updated_at": '2016-06-22T06:13:29.693272Z'
                         }
                     ]
                 }

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -11,6 +11,24 @@ var fixtures_ServiceRating = require('./fixtures_service_rating');
 var fixtures_Pilot = require('./fixtures_pilot');
 
 var utils = require('seed-jsbox-utils').utils;
+var _ = require('lodash');
+
+
+var only_use_fixtures = function(api, params) {
+    params = params || {}
+    // either use an explicit source or read from what's already
+    // loaded during the test harnass setup
+    original_fixtures = params.source || api.http.fixtures.fixtures;
+    numbers = params.numbers || [];
+
+    // clear any previously loaded fixtures during tester setup
+    api.http.fixtures.fixtures = [];
+
+    // load the explicit numbers
+    _.forEach(numbers, function(number) {
+        api.http.fixtures.add(original_fixtures[number]);
+    });
+}
 
 describe("app", function() {
     describe("for ussd_public use", function() {
@@ -727,7 +745,8 @@ describe("app", function() {
                         },
                         message_sender: {
                             url: 'http://ms/api/v1/',
-                            token: 'test MessageSender'
+                            token: 'test MessageSender',
+                            channel: 'default-channel',
                         }
                     },
                     pilot: {
@@ -735,7 +754,7 @@ describe("app", function() {
                         randomisation_treshold: 0.5,
                         api_url: 'http://pilot.example.org/check/',
                         api_token: 'api-token',
-                        channel: 'pilot-channel',
+                        channel: 'pilot-channel'
                     }
                 })
                 .setup(function(api) {
@@ -746,7 +765,7 @@ describe("app", function() {
 
                     // NOTE:    Skipping the hub fixtures are I'm adding them
                     //          explicity as part of each testers setup
-                    // // fixtures_Hub().forEach(api.http.fixtures.add); // fixtures 0 - 49
+                    fixtures_Hub().forEach(api.http.fixtures.add); // fixtures 0 - 49
                     fixtures_StageBasedMessaging().forEach(api.http.fixtures.add); // 50 - 99
                     fixtures_MessageSender().forEach(api.http.fixtures.add); // 100 - 149
                     fixtures_ServiceRating().forEach(api.http.fixtures.add); // 150 - 169
@@ -789,13 +808,29 @@ describe("app", function() {
                     // before it gets there
                     pilot_config = api.config.store.config.pilot
                     pilot_config.randomisation_threshold = 1.0;
+                    only_use_fixtures(api, {
+                        numbers: [
+                            180, // 'get.is.msisdn.27820001001'
+                            183, // 'post.is.msisdn.27820001001'
+                            198, // 'patch.is.identity.cb245673-aa41-4302-ac47-00000001001'
+                            50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                            117, // 'post.ms.outbound.27820001001'
+                        ],
+                    });
                     api.http.fixtures.add(
                         fixtures_Pilot().not_exists('27820001001'));
-                    api.http.fixtures.add(fixtures_Pilot().registration({
-                            address: '27820001001',
-                            reg_type: 'momconnect_prebirth',
-                            language: 'zul_ZA',
-                        }));
+                    api.http.fixtures.add(fixtures_Pilot().post_registration({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '27820001001',
+                        reg_type: 'momconnect_prebirth',
+                        language: 'zul_ZA',
+                    }));
+                    api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '+27820001001',
+                        channel: 'default-channel',
+                        content: 'Congratulations on your pregnancy. You will now get free SMSs about MomConnect. You can register for the full set of FREE helpful messages at a clinic.'
+                    }));
                 })
                 .setup.user.addr("27820001001")
                 .inputs(
@@ -843,12 +878,35 @@ describe("app", function() {
                     // white list the number we're using to trigger the pilot functionality
                     pilot_config = api.config.store.config.pilot
                     pilot_config.whitelist = ['+27820001001'];
-                    api.http.fixtures.add(fixtures_Pilot().registration({
-                            address: '27820001001',
-                            reg_type: 'whatsapp_prebirth',
-                            language: 'zul_ZA',
-
-                        }));
+                    only_use_fixtures(api, {
+                        numbers: [
+                            180, // 'get.is.msisdn.27820001001'
+                            183, // 'post.is.msisdn.27820001001'
+                            198, // 'patch.is.identity.cb245673-aa41-4302-ac47-00000001001'
+                            54, //  "get.sbm.messageset.all"
+                            117, // 'post.ms.outbound.27820001001'
+                        ],
+                    });
+                    // subscribe to the whatsapp_prebirth message set so the pilot
+                    // channel is returned
+                    api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        messagesets: [
+                            62, // whatsapp_prebirth.patient.1,
+                        ]
+                    }))
+                    api.http.fixtures.add(fixtures_Pilot().post_registration({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '27820001001',
+                        reg_type: 'whatsapp_prebirth',
+                        language: 'zul_ZA',
+                    }));
+                    api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '+27820001001',
+                        channel: 'pilot-channel',
+                        content: 'Congratulations on your pregnancy. You will now get free SMSs about MomConnect. You can register for the full set of FREE helpful messages at a clinic.'
+                    }));
                 })
                 .setup.user.addr("27820001001")
                 .inputs(
@@ -872,12 +930,27 @@ describe("app", function() {
                     // white list the number we're using to trigger the pilot functionality
                     pilot_config = api.config.store.config.pilot
                     pilot_config.whitelist = ['+27820001001'];
-                    api.http.fixtures.add(fixtures_Pilot().registration({
-                            address: '27820001001',
-                            reg_type: 'momconnect_prebirth',
-                            language: 'zul_ZA',
+                    only_use_fixtures(api, {
+                        numbers: [
+                            180, // 'get.is.msisdn.27820001001'
+                            183, // 'post.is.msisdn.27820001001'
+                            198, // 'patch.is.identity.cb245673-aa41-4302-ac47-00000001001'
+                            50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                        ],
+                    });
+                    api.http.fixtures.add(fixtures_Pilot().post_registration({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '27820001001',
+                        reg_type: 'momconnect_prebirth',
+                        language: 'zul_ZA',
 
-                        }));
+                    }));
+                    api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
+                        identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        address: '+27820001001',
+                        channel: 'default-channel',
+                        content: 'Congratulations on your pregnancy. You will now get free SMSs about MomConnect. You can register for the full set of FREE helpful messages at a clinic.'
+                    }));
                 })
                 .setup.user.addr("27820001001")
                 .inputs(
@@ -893,6 +966,88 @@ describe("app", function() {
                 })
                 .check.reply.ends_session()
                 .run();
+        });
+
+        it("should use the correct channel when going to state_end_compliment", function() {
+            return tester
+            .setup.user.addr("27820001002")
+            .setup(function(api) {
+                only_use_fixtures(api, {
+                    numbers: [
+                        54, // "get.sbm.messageset.all"
+                        119, // "post.ms.outbound.27820001002"
+                        181, // "get.is.msisdn.27820001002"
+                    ],
+                });
+
+                // subscribe to the whatsapp_prebirth message set so the pilot
+                // channel is returned
+                api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({
+                    identity: 'cb245673-aa41-4302-ac47-00000001002',
+                    messagesets: [
+                        62, // whatsapp_prebirth.patient.1,
+                    ]
+                }))
+                api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
+                    identity: 'cb245673-aa41-4302-ac47-00000001002',
+                    address: '+27820001002',
+                    channel: 'pilot-channel',
+                    content: 'Please reply to this message with your compliment. If it relates to the service at the clinic, include the clinic or clinic worker name. Standard rates apply.'
+                }));
+            })
+            .inputs(
+                {session_event: "new"}
+                , "1"  // state_registered_full - compliment
+            )
+            .check.interaction({
+                state: "state_end_compliment",
+                reply: 'Thank you. We will send you a message ' +
+                    'shortly with instructions on how to send us ' +
+                    'your compliment.'
+            })
+            .check.reply.ends_session()
+            .run();
+        });
+
+        it("should use the correct channel when going to state_end_complaint", function() {
+            return tester
+            .setup.user.addr("27820001002")
+            .setup(function(api) {
+                only_use_fixtures(api, {
+                    numbers: [
+                        54, // "get.sbm.messageset.all"
+                        120, // "post.ms.outbound.27820001002"
+                        181, // "get.is.msisdn.27820001002"
+                    ],
+                });
+                // subscribe to the whatsapp_prebirth message set so the pilot
+                // channel is returned
+                api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({
+                    identity: 'cb245673-aa41-4302-ac47-00000001002',
+                    messagesets: [
+                        62, // whatsapp_prebirth.patient.1,
+                    ]
+                }))
+                api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
+                    identity: 'cb245673-aa41-4302-ac47-00000001002',
+                    address: '+27820001002',
+                    channel: 'pilot-channel',
+                    content: 'Please reply to this message with your complaint. If it relates to the service at the clinic, include the clinic or clinic worker name. Standard rates apply.'
+                }));
+
+            })
+            .inputs(
+                {session_event: "new"}
+                , "2"  // state_registered_full - complaint
+            )
+            .check.interaction({
+                state: "state_end_complaint",
+                reply: 'Thank you. We will send you a message ' +
+                    'shortly with instructions on how to send us ' +
+                    'your complaint.'
+            })
+            .check.reply.ends_session()
+            .run();
         });
     });
 });

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -134,7 +134,7 @@ describe("app", function() {
                         assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [2]);
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                        utils.check_fixtures_used(api, [17, 50, 117, 180, 183, 198]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -233,7 +233,7 @@ describe("app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [125, 180, 183]);
+                    utils.check_fixtures_used(api, [50, 125, 180, 183]);
                 })
                 .run();
             });
@@ -278,7 +278,7 @@ describe("app", function() {
                 )
                 .check.user.answer("redial_sms_sent", false)  // session closed on non-dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                    utils.check_fixtures_used(api, [17, 50, 117, 180, 183, 198]);
                 })
                 .run();
             });
@@ -296,7 +296,7 @@ describe("app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)  // session closed on dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 117, 125, 180, 183, 208]);
+                    utils.check_fixtures_used(api, [17, 50, 117, 125, 180, 183, 208]);
                 })
                 .run();
             });
@@ -522,7 +522,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [1]);
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                            utils.check_fixtures_used(api, [17, 50, 117, 180, 183, 198]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -591,7 +591,7 @@ describe("app", function() {
                         state: "state_end_success"
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [18, 118, 184, 199, 238]);
+                        utils.check_fixtures_used(api, [18, 55, 118, 184, 199, 238]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -735,6 +735,7 @@ describe("app", function() {
                         randomisation_treshold: 0.5,
                         api_url: 'http://pilot.example.org/check/',
                         api_token: 'api-token',
+                        channel: 'pilot-channel',
                     }
                 })
                 .setup(function(api) {


### PR DESCRIPTION
Depending on a user's preferences, which may no longer be around in
self.users.answers state, we should be able to select a different 
channel to send messages.

The welcome message state would still be around.
The compliments & complaints state will likely have expired, this
requires a lookup.

This PR requires the changes in https://github.com/praekelt/seed-jsbox-utils/pull/40