### PR TITLE
Replace check_identity_subscribed call

### DIFF
--- a/go-app-sms_inbound.js
+++ b/go-app-sms_inbound.js
@@ -272,7 +272,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
 
                 return sbm
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         // check if message contains a ussd code

--- a/go-app-sms_nurse.js
+++ b/go-app-sms_nurse.js
@@ -125,7 +125,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
 
                 return sbm
-                .check_identity_subscribed(self.im.user.answers.operator.id, "nurseconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/nurseconnect/])
                 .then(function(identity_subscribed_to_nurseconnect) {
                     if (identity_subscribed_to_nurseconnect) {
                         // check if message contains a ussd code

--- a/go-app-ussd_nurse.js
+++ b/go-app-ussd_nurse.js
@@ -237,7 +237,7 @@ go.app = function() {
                     }
 
                     return sbm
-                    .check_identity_subscribed(self.im.user.answers.operator.id, "nurseconnect")
+                    .is_identity_subscribed(self.im.user.answers.operator.id, [/nurseconnect/])
                     .then(function(identity_subscribed_to_nurseconnect) {
                         if (identity_subscribed_to_nurseconnect) {
                             return self.states.create('state_subscribed');
@@ -896,7 +896,7 @@ go.app = function() {
                     .then(function(identities_found) {
                         if (identities_found.results.length > 0) {
                             return sbm
-                            .check_identity_subscribed(identities_found.results[0].id, "nurseconnect")
+                            .is_identity_subscribed(identities_found.results[0].id, [/nurseconnect/])
                             .then(function(identity_subscribed_to_nurseconnect) {
                                 if (identity_subscribed_to_nurseconnect) {
                                     self.im.user.set_answer("old_msisdn", old_msisdn);

--- a/go-app-ussd_pmtct.js
+++ b/go-app-ussd_pmtct.js
@@ -402,7 +402,7 @@ go.app = function() {
             .then(function(identity) {
                 self.im.user.set_answer("identity", identity);
                 return sbm
-                .check_identity_subscribed(identity.id, "pmtct")
+                .is_identity_subscribed(identity.id, [/pmtct/])
                 .then(function(identity_subscribed_to_pmtct) {
                     if (identity_subscribed_to_pmtct) {
                         return self.im.user

--- a/go-app-ussd_popi_faq.js
+++ b/go-app-ussd_popi_faq.js
@@ -101,7 +101,7 @@ go.app = function() {
 
                 return sbm
                 // check if registered
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         return self.states.create('state_all_questions_view');

--- a/go-app-ussd_popi_user_data.js
+++ b/go-app-ussd_popi_user_data.js
@@ -197,7 +197,7 @@ go.app = function() {
                 
                 return sbm
                 // check that user is registered on momconnect   
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         var promises = [];

--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -122,7 +122,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
 
                 return sbm
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         // check if message contains a ussd code

--- a/src/sms_nurse.js
+++ b/src/sms_nurse.js
@@ -122,7 +122,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
 
                 return sbm
-                .check_identity_subscribed(self.im.user.answers.operator.id, "nurseconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/nurseconnect/])
                 .then(function(identity_subscribed_to_nurseconnect) {
                     if (identity_subscribed_to_nurseconnect) {
                         // check if message contains a ussd code

--- a/src/ussd_nurse.js
+++ b/src/ussd_nurse.js
@@ -234,7 +234,7 @@ go.app = function() {
                     }
 
                     return sbm
-                    .check_identity_subscribed(self.im.user.answers.operator.id, "nurseconnect")
+                    .is_identity_subscribed(self.im.user.answers.operator.id, [/nurseconnect/])
                     .then(function(identity_subscribed_to_nurseconnect) {
                         if (identity_subscribed_to_nurseconnect) {
                             return self.states.create('state_subscribed');
@@ -893,7 +893,7 @@ go.app = function() {
                     .then(function(identities_found) {
                         if (identities_found.results.length > 0) {
                             return sbm
-                            .check_identity_subscribed(identities_found.results[0].id, "nurseconnect")
+                            .is_identity_subscribed(identities_found.results[0].id, [/nurseconnect/])
                             .then(function(identity_subscribed_to_nurseconnect) {
                                 if (identity_subscribed_to_nurseconnect) {
                                     self.im.user.set_answer("old_msisdn", old_msisdn);

--- a/src/ussd_pmtct.js
+++ b/src/ussd_pmtct.js
@@ -399,7 +399,7 @@ go.app = function() {
             .then(function(identity) {
                 self.im.user.set_answer("identity", identity);
                 return sbm
-                .check_identity_subscribed(identity.id, "pmtct")
+                .is_identity_subscribed(identity.id, [/pmtct/])
                 .then(function(identity_subscribed_to_pmtct) {
                     if (identity_subscribed_to_pmtct) {
                         return self.im.user

--- a/src/ussd_popi_faq.js
+++ b/src/ussd_popi_faq.js
@@ -98,7 +98,7 @@ go.app = function() {
 
                 return sbm
                 // check if registered
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         return self.states.create('state_all_questions_view');

--- a/src/ussd_popi_user_data.js
+++ b/src/ussd_popi_user_data.js
@@ -194,7 +194,7 @@ go.app = function() {
                 
                 return sbm
                 // check that user is registered on momconnect   
-                .check_identity_subscribed(self.im.user.answers.operator.id, "momconnect")
+                .is_identity_subscribed(self.im.user.answers.operator.id, [/momconnect/])
                 .then(function(identity_subscribed_to_momconnect) {
                     if (identity_subscribed_to_momconnect) {
                         var promises = [];


### PR DESCRIPTION
This is deprecated and should be replaced with `is_identity_subscribed`.

In the version of seed-jsbox-utils that we're using, they have almost
identical behaviour:

https://github.com/praekelt/seed-jsbox-utils/blob/0.1.17/lib/stage_based_messaging.js#L162-L189