### PR TITLE
Fix prebirth subscription test

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -508,7 +508,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
                 self.im.user.set_answer("operator_msisdn", operator_msisdn);
 
-                return sbm.is_identity_subscribed(identity.id, [/prebirth/]);
+                return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
             })
             .then(function(has_active_subscription) {
                 self.im.user.set_answer("has_active_subscription", has_active_subscription);
@@ -648,7 +648,7 @@ go.app = function() {
                         self.im.user.set_answer("registrant", identity);
                         self.im.user.set_answer("registrant_msisdn", registrant_msisdn);
 
-                        return sbm.is_identity_subscribed(identity.id, [/prebirth/]);
+                        return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
                     })
                     .then(function(has_active_subscription) {
                         self.im.user.set_answer("has_active_subscription", has_active_subscription);

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -358,7 +358,7 @@ go.app = function() {
                 self.im.user.set_answer("operator", identity);
                 self.im.user.set_answer("operator_msisdn", operator_msisdn);
 
-                return sbm.is_identity_subscribed(identity.id, [/prebirth/]);
+                return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
             })
             .then(function(has_active_subscription) {
                 self.im.user.set_answer("has_active_subscription", has_active_subscription);
@@ -498,7 +498,7 @@ go.app = function() {
                         self.im.user.set_answer("registrant", identity);
                         self.im.user.set_answer("registrant_msisdn", registrant_msisdn);
 
-                        return sbm.is_identity_subscribed(identity.id, [/prebirth/]);
+                        return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
                     })
                     .then(function(has_active_subscription) {
                         self.im.user.set_answer("has_active_subscription", has_active_subscription);


### PR DESCRIPTION
@KaitCrawford pointed out that we also have a `prebirth.hw_partial` message set and we do want somebody to be able to have a partial and a full subscription at the same time.

The string to match is a regex so we only want to match a literal dot: `\.`