### PR TITLE
Optimize the WhatsApp number checks

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -709,10 +709,15 @@ go.app = function() {
                 });
         };
 
-        self.is_valid_recipient_for_pilot = function (params) {
+        self.is_valid_recipient_for_pilot = function (default_params) {
             var pilot_config = self.im.config.pilot || {};
             var api_url = pilot_config.api_url;
             var api_token = pilot_config.api_token;
+            var api_number = pilot_config.api_number;
+
+            var params = _.merge({
+                number: api_number,
+            }, default_params);
 
             // Otherwise check the API
             return new JsonApi(self.im, {

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -559,10 +559,15 @@ go.app = function() {
                 });
         };
 
-        self.is_valid_recipient_for_pilot = function (params) {
+        self.is_valid_recipient_for_pilot = function (default_params) {
             var pilot_config = self.im.config.pilot || {};
             var api_url = pilot_config.api_url;
             var api_token = pilot_config.api_token;
+            var api_number = pilot_config.api_number;
+
+            var params = _.merge({
+                number: api_number,
+            }, default_params);
 
             // Otherwise check the API
             return new JsonApi(self.im, {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -390,6 +390,20 @@ go.app = function() {
             return is
             .get_or_create_identity({"msisdn": registrant_msisdn})
             .then(function(identity) {
+                // We're calling this in the start without waiting for the results,
+                // this is a quick call but WhatsApp in the background continues querying
+                // this contact, this means when we call it again the result will likely
+                // be available immediately when we call with with `wait` = `true`.
+                return self
+                    .can_participate_in_pilot({
+                        address: registrant_msisdn,
+                        wait: false,
+                    })
+                    .then(function(ignored_result) {
+                        return identity;
+                    });
+            })
+            .then(function(identity) {
                 self.im.user.set_answer("registrant", identity);
                 self.im.user.set_answer("registrant_msisdn", registrant_msisdn);
 
@@ -567,8 +581,12 @@ go.app = function() {
         });
 
         self.add('state_pilot_randomisation', function(name) {  // interstitial state
+            var msisdn = utils.normalize_msisdn(self.im.user.addr, '27');
             return self
-                .can_participate_in_pilot()
+                .can_participate_in_pilot({
+                    address: msisdn,
+                    wait: true,
+                })
                 .then(function(yes_or_no) {
                     return yes_or_no
                         ? self.states.create('state_pilot')
@@ -576,7 +594,9 @@ go.app = function() {
                 });
         });
 
-        self.can_participate_in_pilot = function () {
+        self.can_participate_in_pilot = function (params) {
+            params = params || {};
+
             if(_.isEmpty(self.im.config.pilot)) {
                 // If unconfigured return false
                 return Q(false);
@@ -587,7 +607,14 @@ go.app = function() {
             var randomisation_threshold = pilot_config.randomisation_threshold || 0.0;
             var api_url = pilot_config.api_url;
             var api_token = pilot_config.api_token;
-            var msisdn = utils.normalize_msisdn(self.im.user.addr, '27');
+            var api_number = pilot_config.api_number;
+
+            var default_params = _.merge({
+                number: api_number,
+            }, params);
+
+            var msisdn = params.address;
+
             // Always allow people on the whitelist
             if(whitelist.indexOf(msisdn) > -1) {
                 return Q(true);
@@ -598,10 +625,8 @@ go.app = function() {
                     'Authorization': ['Token ' + api_token]
                 }})
                 .get(api_url, {
-                    params: {
-                        address: msisdn,
-                        wait: true,
-                    }})
+                    params: default_params,
+                })
                 .then(function(response) {
                     existing = _.filter(response.data, function(obj) { return obj.exists === true; });
                     if(_.isEmpty(existing)) {

--- a/test/fixtures_pilot.js
+++ b/test/fixtures_pilot.js
@@ -11,6 +11,7 @@ module.exports = function() {
                 },
                 'url': 'http://pilot.example.org/check/',
                 'params': {
+                    'number': params.number,
                     'wait': '' + params.wait, // force to string type for fixture lookups to work
                     'address': params.address,
                 },

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -1537,6 +1537,7 @@ describe("app", function() {
                     // waiting for results
                     pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
@@ -1593,6 +1594,7 @@ describe("app", function() {
                     // waiting for results
                     pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
@@ -1648,6 +1650,7 @@ describe("app", function() {
                     // waiting for results
                     pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
@@ -1703,11 +1706,13 @@ describe("app", function() {
                     // API call for checking pilot readiness
                     async_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
                     sync_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true
                         }));
@@ -1751,11 +1756,13 @@ describe("app", function() {
                     // API call for checking pilot readiness
                     async_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
                     sync_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().not_exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true
                         }));
@@ -1794,11 +1801,13 @@ describe("app", function() {
                     // API call for checking pilot readiness
                     async_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: false
                         }));
                     sync_pilot_fixture = api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true
                         }));
@@ -1839,11 +1848,13 @@ describe("app", function() {
                         // API call for checking pilot readiness
                         api.http.fixtures.add(
                             fixtures_Pilot().exists({
+                                number: '+27123456789',
                                 address: '+27820001001',
                                 wait: false
                         })),
                         api.http.fixtures.add(
                             fixtures_Pilot().exists({
+                                number: '+27123456789',
                                 address: '+27820001001',
                                 wait: true
                         })),

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -14,7 +14,7 @@ var utils = require('seed-jsbox-utils').utils;
 var test_utils = require('./test_utils');
 var _ = require('lodash');
 
-describe("app", function() {
+describe("ussd_public app", function() {
     describe("for ussd_public use", function() {
         var app;
         var tester;
@@ -770,6 +770,14 @@ describe("app", function() {
                     pilot_config.randomisation_threshold = 1.0;
                     api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
+
+                    api.http.fixtures.add(
+                        fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true,
                         }));
@@ -802,6 +810,13 @@ describe("app", function() {
                     pilot_config.nudge_threshold = 1.0;
                     api.http.fixtures.add(
                         fixtures_Pilot().exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
+                    api.http.fixtures.add(
+                        fixtures_Pilot().exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true,
                         }));
@@ -842,6 +857,14 @@ describe("app", function() {
                     });
                     api.http.fixtures.add(
                         fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
+
+                    api.http.fixtures.add(
+                        fixtures_Pilot().not_exists({
+                            number: '+27123456789',
                             address: '+27820001001',
                             wait: true,
                         }));
@@ -925,6 +948,13 @@ describe("app", function() {
                         ],
                     });
 
+                    api.http.fixtures.add(
+                        fixtures_Pilot().exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
+
                     // NOTE:    we're not providing a fixture for the whatsapp_prebirth message set
                     //          it should be inferred from the local state
 
@@ -980,7 +1010,14 @@ describe("app", function() {
                         ],
                     });
 
-                    // subscribe to the whatsapp_prebirth message set so the pilot
+                    api.http.fixtures.add(
+                        fixtures_Pilot().exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
+
+                        // subscribe to the whatsapp_prebirth message set so the pilot
                     // channel is returned
                     api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({
                         identity: 'cb245673-aa41-4302-ac47-00000001001',
@@ -1019,6 +1056,12 @@ describe("app", function() {
                             50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
                         ],
                     });
+                    api.http.fixtures.add(
+                        fixtures_Pilot().exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: false,
+                        }));
                     api.http.fixtures.add(
                         fixtures_Pilot().annotate({
                             number: '+27123456789',
@@ -1072,6 +1115,12 @@ describe("app", function() {
                     ],
                 });
 
+                api.http.fixtures.add(
+                    fixtures_Pilot().exists({
+                        number: '+27123456789',
+                        address: '+27820001002',
+                        wait: false,
+                    }));
                 // subscribe to the whatsapp_prebirth message set so the pilot
                 // channel is returned
                 api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({
@@ -1112,6 +1161,12 @@ describe("app", function() {
                         181, // "get.is.msisdn.27820001002"
                     ],
                 });
+                api.http.fixtures.add(
+                    fixtures_Pilot().exists({
+                        number: '+27123456789',
+                        address: '+27820001002',
+                        wait: false,
+                    }));
                 // subscribe to the whatsapp_prebirth message set so the pilot
                 // channel is returned
                 api.http.fixtures.add(fixtures_Pilot().subscribe_id_to({


### PR DESCRIPTION
1. Specify the number we're wanting to check for.

If we don't specify the number, all numbers for the account are checked
and that generates more load than necessary.

2. In the public registration line, make 2 separate calls (like we do for clinics)

The first call has "wait=False" which forks the WhatsApp query to the background.
When that returns, it'll be stored in the local db.

The second call has "wait=True", if it's available in the local db then the results
are returned immediately, otherwise it'll be as before and it'll wait until
the WhatsApp service replies.