### PR TITLE
Run all ussd_nurse tests

### DIFF
--- a/test/ussd_nurse.test.js
+++ b/test/ussd_nurse.test.js
@@ -141,7 +141,7 @@ describe("app", function() {
                         })
                         .run();
                 });
-                it.only("should record metrics", function() {
+                it("should record metrics", function() {
                     return tester
                         .setup.user.addr('27820001002')
                         .inputs(


### PR DESCRIPTION
The call to `only()` was set in 59df71509e902b8dfad4c033bceebf970c530ab9 which I think was by accident while debugging.

All the tests still pass!