### PR TITLE
Change SMS keyword logic

### DIFF
--- a/go-app-sms_inbound.js
+++ b/go-app-sms_inbound.js
@@ -288,7 +288,8 @@ go.app = function() {
                                     return self.states.create("state_opt_in_enter");
                                 case "BABY": case "USANA": case "SANA": case "BABA":
                                 case "BABBY": case "LESEA": case "BBY": case "BABYA":
-                                case "OBABY": case "NGWANA":
+                                case "OBABY": case "NGWANA": case "BABY BOY":
+                                case "BABY GIRL":
                                     return self.states.create("state_baby_enter");
                                 case "WA": case "WHATSAPP": case "WHATSUP":
                                 case "WASSUP": case "WATSAPP": case "WHATSAP":

--- a/go-app-sms_inbound.js
+++ b/go-app-sms_inbound.js
@@ -262,6 +262,16 @@ go.app = function() {
             return (today_utc.hour() < opening_time || today_utc.hour() >= closing_time);
         };
 
+        self.get_keyword = function(text) {
+            // Cleans the input and capitalizes it for comparison to keyword
+            // list
+            return text
+                .replace(/\W/g, '')     // Remove non-letters
+                .trim()                 // Remove whitespace
+                .toUpperCase()          // Capitalize
+                ;
+        };
+
         self.states.add("state_start", function() {
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "27");
             self.im.user.set_answer("operator_msisdn", msisdn);
@@ -280,7 +290,7 @@ go.app = function() {
                             return self.states.create("state_dial_not_sms");
                         } else {
                             // get the first word, remove non-alphanumerics, capitalise
-                            switch (utils.get_clean_first_word(self.im.msg.content)) {
+                            switch (self.get_keyword(self.im.msg.content)) {
                                 case "STOP": case "END": case "CANCEL": case "UNSUBSCRIBE":
                                 case "QUIT": case "BLOCK":
                                     return self.states.create("state_opt_out_enter");

--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -138,7 +138,8 @@ go.app = function() {
                                     return self.states.create("state_opt_in_enter");
                                 case "BABY": case "USANA": case "SANA": case "BABA":
                                 case "BABBY": case "LESEA": case "BBY": case "BABYA":
-                                case "OBABY": case "NGWANA":
+                                case "OBABY": case "NGWANA": case "BABY BOY":
+                                case "BABY GIRL":
                                     return self.states.create("state_baby_enter");
                                 case "WA": case "WHATSAPP": case "WHATSUP":
                                 case "WASSUP": case "WATSAPP": case "WHATSAP":

--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -112,6 +112,16 @@ go.app = function() {
             return (today_utc.hour() < opening_time || today_utc.hour() >= closing_time);
         };
 
+        self.get_keyword = function(text) {
+            // Cleans the input and capitalizes it for comparison to keyword
+            // list
+            return text
+                .replace(/\W/g, '')     // Remove non-letters
+                .trim()                 // Remove whitespace
+                .toUpperCase()          // Capitalize
+                ;
+        };
+
         self.states.add("state_start", function() {
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "27");
             self.im.user.set_answer("operator_msisdn", msisdn);
@@ -130,7 +140,7 @@ go.app = function() {
                             return self.states.create("state_dial_not_sms");
                         } else {
                             // get the first word, remove non-alphanumerics, capitalise
-                            switch (utils.get_clean_first_word(self.im.msg.content)) {
+                            switch (self.get_keyword(self.im.msg.content)) {
                                 case "STOP": case "END": case "CANCEL": case "UNSUBSCRIBE":
                                 case "QUIT": case "BLOCK":
                                     return self.states.create("state_opt_out_enter");

--- a/test/sms_inbound.test.js
+++ b/test/sms_inbound.test.js
@@ -264,7 +264,7 @@ describe("app", function() {
             it("STOP - should set their opt out status", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('"stop" in the name of love')
+                    .inputs('"stop"')
                     .check.interaction({
                         state: 'state_opt_out',
                         reply:
@@ -375,7 +375,7 @@ describe("app", function() {
             it("should switch their subscription to baby protocol", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('baBy has been born, bub')
+                    .inputs('baBy')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -390,7 +390,7 @@ describe("app", function() {
             it("using 'baby' keyword 'usana'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('usana has been born, bub')
+                    .inputs('usana')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -405,7 +405,7 @@ describe("app", function() {
             it("using 'baby' keyword 'sana'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('sana has been born, bub')
+                    .inputs('sana')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -420,7 +420,7 @@ describe("app", function() {
             it("using 'baby' keyword 'baba'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('baba has been born, bub')
+                    .inputs('baba')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -435,7 +435,7 @@ describe("app", function() {
             it("using 'baby' keyword 'babby'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('babby has been born, bub')
+                    .inputs('babby')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -450,7 +450,7 @@ describe("app", function() {
             it("using 'baby' keyword 'lesea'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('lesea has been born, bub')
+                    .inputs('lesea')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -465,7 +465,7 @@ describe("app", function() {
             it("using 'baby' keyword 'bby'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('bby has been born, bub')
+                    .inputs('bby.')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -480,7 +480,7 @@ describe("app", function() {
             it("using 'baby' keyword 'babya'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('babya has been born, bub')
+                    .inputs('babya ')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -495,7 +495,7 @@ describe("app", function() {
             it("using 'baby' keyword 'obaby'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('obaby has been born, bub')
+                    .inputs('obaby ')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -510,7 +510,7 @@ describe("app", function() {
             it("using 'baby' keyword 'ngwana'", function() {
                 return tester
                     .setup.user.addr('27820001002')
-                    .inputs('Ngwana has been born, bub')
+                    .inputs('Ngwana ')
                     .check.interaction({
                         state: 'state_baby',
                         reply:
@@ -561,7 +561,7 @@ describe("app", function() {
                     // Don't care about character limit for this SMS
                     .setup.char_limit(320)
                     .setup.user.addr('27820001002')
-                    .inputs('sms please')
+                    .inputs('sms')
                     .check.interaction({
                         state: 'state_channel_switch',
                         reply: 
@@ -608,7 +608,7 @@ describe("app", function() {
                     // Don't care about character limit for this SMS
                     .setup.char_limit(320)
                     .setup.user.addr('27820001002')
-                    .inputs('watsapp pls')
+                    .inputs('watsapp')
                     .check.interaction({
                         state: 'state_channel_switch',
                         reply: 


### PR DESCRIPTION
Currently, the logic is that if the FIRST word matches the keyword, then it is triggered.

We want to change this, so that the whole message has to match the keyword (minus non-word characters and whitespace, and case insensitive)