### PR TITLE
Make HTTP request an intermeditate state

### DIFF
--- a/go-app-sms_inbound.js
+++ b/go-app-sms_inbound.js
@@ -304,11 +304,11 @@ go.app = function() {
                                 case "WA": case "WHATSAPP": case "WHATSUP":
                                 case "WASSUP": case "WATSAPP": case "WHATSAP":
                                 case "WATSAP":
-                                    return self.states.create("state_channel_switch", {
+                                    return self.states.create("state_channel_switch_enter", {
                                         channel: "whatsapp"
                                     });
                                 case "SMS":
-                                    return self.states.create("state_channel_switch", {
+                                    return self.states.create("state_channel_switch_enter", {
                                         channel: "sms"
                                     });
                                 default: // Logs a support ticket
@@ -457,17 +457,7 @@ go.app = function() {
             });
         });
 
-        self.states.add("state_channel_switch", function(name, opts) {
-            var whatsapp_response = $(
-                "Thank you. You will get messages on WhatsApp. To change how " +
-                "you get messages, dial *134*550*7#, then choose 2. Or reply " +
-                "to any message with 'SMS' to get them via SMS, or 'WA' for " +
-                "WhatsApp.");
-            var sms_response = $(
-                "Thank you. You will get messages on SMS. To change how you " +
-                "get messages, dial *134*550*7#, then choose 2. Or reply to " +
-                "any message with 'SMS' to get them via SMS, or 'WA' for " +
-                "WhatsApp.");
+        self.states.add("state_channel_switch_enter", function(name, opts) {
             var change_info = {
                 "registrant_id": self.im.user.answers.operator.id,
                 "action": "switch_channel",
@@ -479,10 +469,25 @@ go.app = function() {
             return hub
             .create_change(change_info)
             .then(function() {
-                return new EndState(name, {
-                    text: opts.channel == 'sms' ? sms_response : whatsapp_response,
-                    next: 'state_start'
-                });
+                return self.states.create('state_channel_switch', opts);
+            });
+        });
+
+        self.states.add("state_channel_switch", function(name, opts) {
+            var whatsapp_response = $(
+                "Thank you. You will get messages on WhatsApp. To change how " +
+                "you get messages, dial *134*550*7#, then choose 2. Or reply " +
+                "to any message with 'SMS' to get them via SMS, or 'WA' for " +
+                "WhatsApp.");
+            var sms_response = $(
+                "Thank you. You will get messages on SMS. To change how you " +
+                "get messages, dial *134*550*7#, then choose 2. Or reply to " +
+                "any message with 'SMS' to get them via SMS, or 'WA' for " +
+                "WhatsApp.");
+
+            return new EndState(name, {
+                text: opts.channel == 'sms' ? sms_response : whatsapp_response,
+                next: 'state_start'
             });
         });
 

--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -154,11 +154,11 @@ go.app = function() {
                                 case "WA": case "WHATSAPP": case "WHATSUP":
                                 case "WASSUP": case "WATSAPP": case "WHATSAP":
                                 case "WATSAP":
-                                    return self.states.create("state_channel_switch", {
+                                    return self.states.create("state_channel_switch_enter", {
                                         channel: "whatsapp"
                                     });
                                 case "SMS":
-                                    return self.states.create("state_channel_switch", {
+                                    return self.states.create("state_channel_switch_enter", {
                                         channel: "sms"
                                     });
                                 default: // Logs a support ticket
@@ -307,17 +307,7 @@ go.app = function() {
             });
         });
 
-        self.states.add("state_channel_switch", function(name, opts) {
-            var whatsapp_response = $(
-                "Thank you. You will get messages on WhatsApp. To change how " +
-                "you get messages, dial *134*550*7#, then choose 2. Or reply " +
-                "to any message with 'SMS' to get them via SMS, or 'WA' for " +
-                "WhatsApp.");
-            var sms_response = $(
-                "Thank you. You will get messages on SMS. To change how you " +
-                "get messages, dial *134*550*7#, then choose 2. Or reply to " +
-                "any message with 'SMS' to get them via SMS, or 'WA' for " +
-                "WhatsApp.");
+        self.states.add("state_channel_switch_enter", function(name, opts) {
             var change_info = {
                 "registrant_id": self.im.user.answers.operator.id,
                 "action": "switch_channel",
@@ -329,10 +319,25 @@ go.app = function() {
             return hub
             .create_change(change_info)
             .then(function() {
-                return new EndState(name, {
-                    text: opts.channel == 'sms' ? sms_response : whatsapp_response,
-                    next: 'state_start'
-                });
+                return self.states.create('state_channel_switch', opts);
+            });
+        });
+
+        self.states.add("state_channel_switch", function(name, opts) {
+            var whatsapp_response = $(
+                "Thank you. You will get messages on WhatsApp. To change how " +
+                "you get messages, dial *134*550*7#, then choose 2. Or reply " +
+                "to any message with 'SMS' to get them via SMS, or 'WA' for " +
+                "WhatsApp.");
+            var sms_response = $(
+                "Thank you. You will get messages on SMS. To change how you " +
+                "get messages, dial *134*550*7#, then choose 2. Or reply to " +
+                "any message with 'SMS' to get them via SMS, or 'WA' for " +
+                "WhatsApp.");
+
+            return new EndState(name, {
+                text: opts.channel == 'sms' ? sms_response : whatsapp_response,
+                next: 'state_start'
             });
         });
 


### PR DESCRIPTION
Since the channel switch HTTP request is not in an intermediate state, if the user sends in another message, it runs that state (and therefore the HTTP request) again, before moving on to the starting state.

This PR separates the HTTP request into a separate intermediate state, so that the request isn't run twice.