### PR TITLE
Change SMSs to messages for welcome message

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -456,7 +456,7 @@ go.app = function() {
                             self.im.user.answers.registrant.id,
                             self.im.user.answers.registrant_msisdn,
                             self.im.user.i18n($(
-                                "Welcome. To stop getting SMSs dial {{optout_channel}} or for more " +
+                                "Welcome. To stop getting messages dial {{optout_channel}} or for more " +
                                 "services dial {{public_channel}} (No Cost). Standard rates apply " +
                                 "when replying to any SMS from MomConnect."
                             ).context({

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -306,7 +306,7 @@ go.app = function() {
                             self.im.user.answers.registrant.id,
                             self.im.user.answers.registrant_msisdn,
                             self.im.user.i18n($(
-                                "Welcome. To stop getting SMSs dial {{optout_channel}} or for more " +
+                                "Welcome. To stop getting messages dial {{optout_channel}} or for more " +
                                 "services dial {{public_channel}} (No Cost). Standard rates apply " +
                                 "when replying to any SMS from MomConnect."
                             ).context({

--- a/test/fixtures_message_sender.js
+++ b/test/fixtures_message_sender.js
@@ -507,7 +507,7 @@ module.exports = function() {
                 "data": {
                     "to_identity": "cb245673-aa41-4302-ac47-00000001001",
                     "to_addr": "+27820001001",
-                    "content": "Welcome. To stop getting SMSs dial *120*550*1# or for more services dial *120*550# (No Cost). Standard rates apply when replying to any SMS from MomConnect.",
+                    "content": "Welcome. To stop getting messages dial *120*550*1# or for more services dial *120*550# (No Cost). Standard rates apply when replying to any SMS from MomConnect.",
                     "metadata": {}
                 }
             },

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -1902,7 +1902,7 @@ describe("app", function() {
                             address: '+27820001001',
                             channel: 'pilot-channel',
                             content: [
-                                'Welcome. To stop getting SMSs dial *120*550*1# or for more services dial *120*550# (No Cost). ',
+                                'Welcome. To stop getting messages dial *120*550*1# or for more services dial *120*550# (No Cost). ',
                                 'Standard rates apply when replying to any SMS from MomConnect.'
                             ].join('')
                         }))


### PR DESCRIPTION
Currently, the welcome message refers to "SMSs", which is confusing for when this message is being sent over whatsapp. This PR changes that so that it refers to the agnostic "messages"