### PR TITLE
Remove need for double-opt in

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -573,8 +573,8 @@ go.app = function() {
             return new ChoiceState(name, {
                 question: $(
                     'We need to collect, store & use her info. She ' +
-                    'may get messages on public holidays & weekends. ' +
-                    'Does she consent?'),
+                    'may get WhatsApp or SMS messages on public ' +
+                    'holidays & weekends. Does she consent?'),
                 choices: [
                     new Choice('yes', $('Yes')),
                     new Choice('no', $('No')),
@@ -901,7 +901,7 @@ go.app = function() {
                 next: function(content) {
                     var mom_dob = utils.extract_za_id_dob(content);
                     self.im.user.set_answer("mom_dob", mom_dob);
-                    return 'state_pilot_randomisation';
+                    return 'state_pilot_check';
                 }
             });
         });
@@ -935,7 +935,7 @@ go.app = function() {
                         return error;
                     }
                 },
-                next: 'state_pilot_randomisation'
+                next: 'state_pilot_check'
             });
         });
 
@@ -987,7 +987,7 @@ go.app = function() {
                                utils.double_digit_number(content));
                     self.im.user.set_answer("mom_dob", dob);
                     if (utils.is_valid_date(dob, 'YYYY-MM-DD')) {
-                        return 'state_pilot_randomisation';
+                        return 'state_pilot_check';
                     } else {
                         return 'state_invalid_dob';
                     }
@@ -1008,55 +1008,22 @@ go.app = function() {
             });
         });
 
-        self.add('state_pilot_randomisation', function(name) {  // interstitial state
-            var facilitycode = self.im.user.answers.state_clinic_code;
+        self.add('state_pilot_check', function (name) {   // interstitial state
             var address = self.im.user.answers.registrant_msisdn;
             return self
-                .can_participate_in_pilot(facilitycode)
-                .then(function(confirmed) {
-                    if(confirmed) {
-                        // NOTE:    Here we run the same check again but instead
-                        //          tell it to wait for the result but this should
-                        //          now be quick as it's already completed
-                        //          at the gateway level
-                        return self.is_valid_recipient_for_pilot({
-                            msisdns: [address],
-                            wait: true,
-                        });
-                    } else {
-                        return false;
-                    }
+                // NOTE:    Here we run the same check again but instead
+                //          tell it to wait for the result but this should
+                //          now be quick as it's already completed
+                //          at the gateway level
+                .is_valid_recipient_for_pilot({
+                    msisdns: [address],
+                    wait: true,
                 })
                 .then(function(confirmed) {
                     self.im.user.set_answer('registered_on_whatsapp', confirmed);
-                    return confirmed
-                        ? self.states.create('state_pilot')
-                        : self.states.create('state_language');
+                    self.im.user.set_answer('state_pilot', confirmed ? 'whatsapp' : 'sms');
+                    return self.states.create('state_language');
                 });
-        });
-
-        self.add('state_pilot', function(name) {
-            var pilot_config = self.im.config.pilot || {};
-            var nudge_threshold = pilot_config.nudge_threshold || 0.0;
-            var question = $('How would the pregnant mother like to receive the messages?');
-            var whatsapp_label = $('WhatsApp');
-            var sms_label = $('SMS');
-
-            if(self.im.user.answers.state_language == 'eng_ZA' && Math.random() < nudge_threshold) {
-                question = $("Would the pregnant mother prefer to receive messages via WhatsApp?");
-                whatsapp_label = $('Yes');
-                sms_label = $('No');
-            }
-
-            self.im.user.set_answer("state_pilot_question", question.args[0]);
-            return new ChoiceState(name, {
-                question: question,
-                choices: [
-                    new Choice('whatsapp', whatsapp_label),
-                    new Choice('sms', sms_label),
-                ],
-                next: 'state_language'
-            });
         });
 
         self.add('state_language', function(name) {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -748,10 +748,6 @@ go.app = function() {
             var api_token = pilot_config.api_token;
             var api_number = pilot_config.api_number;
 
-            // var default_params = _.merge({
-            //     number: api_number,
-            // }, params);
-
             var msisdn = params.address;
 
             // Always allow people on the whitelist

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -423,8 +423,8 @@ go.app = function() {
             return new ChoiceState(name, {
                 question: $(
                     'We need to collect, store & use her info. She ' +
-                    'may get messages on public holidays & weekends. ' +
-                    'Does she consent?'),
+                    'may get WhatsApp or SMS messages on public ' +
+                    'holidays & weekends. Does she consent?'),
                 choices: [
                     new Choice('yes', $('Yes')),
                     new Choice('no', $('No')),
@@ -879,34 +879,9 @@ go.app = function() {
                 })
                 .then(function(confirmed) {
                     self.im.user.set_answer('registered_on_whatsapp', confirmed);
-                    return confirmed
-                        ? self.states.create('state_pilot')
-                        : self.states.create('state_language');
+                    self.im.user.set_answer('state_pilot', confirmed ? 'whatsapp' : 'sms');
+                    return self.states.create('state_language');
                 });
-        });
-
-        self.add('state_pilot', function(name) {
-            var pilot_config = self.im.config.pilot || {};
-            var nudge_threshold = pilot_config.nudge_threshold || 0.0;
-            var question = $('How would the pregnant mother like to receive the messages?');
-            var whatsapp_label = $('WhatsApp');
-            var sms_label = $('SMS');
-
-            if(self.im.user.answers.state_language == 'eng_ZA' && Math.random() < nudge_threshold) {
-                question = $("Would the pregnant mother prefer to receive messages via WhatsApp?");
-                whatsapp_label = $('Yes');
-                sms_label = $('No');
-            }
-
-            self.im.user.set_answer("state_pilot_question", question.args[0]);
-            return new ChoiceState(name, {
-                question: question,
-                choices: [
-                    new Choice('whatsapp', whatsapp_label),
-                    new Choice('sms', sms_label),
-                ],
-                next: 'state_language'
-            });
         });
 
         self.add('state_language', function(name) {

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -751,7 +751,7 @@ go.app = function() {
                 next: function(content) {
                     var mom_dob = utils.extract_za_id_dob(content);
                     self.im.user.set_answer("mom_dob", mom_dob);
-                    return 'state_pilot_randomisation';
+                    return 'state_pilot_check';
                 }
             });
         });
@@ -785,7 +785,7 @@ go.app = function() {
                         return error;
                     }
                 },
-                next: 'state_pilot_randomisation'
+                next: 'state_pilot_check'
             });
         });
 
@@ -837,7 +837,7 @@ go.app = function() {
                                utils.double_digit_number(content));
                     self.im.user.set_answer("mom_dob", dob);
                     if (utils.is_valid_date(dob, 'YYYY-MM-DD')) {
-                        return 'state_pilot_randomisation';
+                        return 'state_pilot_check';
                     } else {
                         return 'state_invalid_dob';
                     }
@@ -858,31 +858,23 @@ go.app = function() {
             });
         });
 
-        self.add('state_pilot_randomisation', function(name) {  // interstitial state
-            var facilitycode = self.im.user.answers.state_clinic_code;
+        self.add('state_pilot_check', function (name) {   // interstitial state
             var address = self.im.user.answers.registrant_msisdn;
             return self
-                .can_participate_in_pilot(facilitycode)
-                .then(function(confirmed) {
-                    if(confirmed) {
-                        // NOTE:    Here we run the same check again but instead
-                        //          tell it to wait for the result but this should
-                        //          now be quick as it's already completed
-                        //          at the gateway level
-                        return self.is_valid_recipient_for_pilot({
-                            msisdns: [address],
-                            wait: true,
-                        });
-                    } else {
-                        return false;
-                    }
+                // NOTE:    Here we run the same check again but instead
+                //          tell it to wait for the result but this should
+                //          now be quick as it's already completed
+                //          at the gateway level
+                .is_valid_recipient_for_pilot({
+                    msisdns: [address],
+                    wait: true,
                 })
                 .then(function(confirmed) {
                     self.im.user.set_answer('registered_on_whatsapp', confirmed);
                     self.im.user.set_answer('state_pilot', confirmed ? 'whatsapp' : 'sms');
                     return self.states.create('state_language');
                 });
-        });
+        })
 
         self.add('state_language', function(name) {
             return new PaginatedChoiceState(name, {

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -874,7 +874,7 @@ go.app = function() {
                     self.im.user.set_answer('state_pilot', confirmed ? 'whatsapp' : 'sms');
                     return self.states.create('state_language');
                 });
-        })
+        });
 
         self.add('state_language', function(name) {
             return new PaginatedChoiceState(name, {

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -60,6 +60,13 @@ describe("app", function() {
                             token: 'test StageBasedMessaging'
                         }
                     },
+                    pilot: {
+                        facilitycode_whitelist: [],
+                        api_url: 'http://pilot.example.org/api/v1/lookups/',
+                        api_token: 'api-token',
+                        api_number: '+27123456789',
+                        channel: 'pilot-channel',
+                    }
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};
@@ -345,6 +352,26 @@ describe("app", function() {
             it("should increment metric according to number of sessions", function() {
                 return tester
                     .setup.user.addr('27820001001')
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                4, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                123, // create outbound message (clinic dialback)
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                                204, // update identity cb245673-aa41-4302-ac47-00000001001
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs(
                         {session_event: 'new'}  // dial in
                         , "1"  // state_start - yes
@@ -367,9 +394,6 @@ describe("app", function() {
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
                         assert.deepEqual(metrics['test.ussd_clinic.avg.sessions_to_register'].values, [2]);
-                    })
-                    .check(function(api) {
-                        utils.check_fixtures_used(api, [4, 50, 116, 123, 174, 180, 183, 204]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -536,11 +560,28 @@ describe("app", function() {
 
                 return tester
                 .setup.user.addr("27820001001")
+                .setup(function(api) {
+                    test_utils.only_use_fixtures(api, {
+                        numbers: [
+                            4, // register cb245673-aa41-4302-ac47-00000001001
+                            50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                            116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                            123, // create outbound message (clinic dialback)
+                            174, // Jembi Clinic Code validation - code 123456
+                            180, // 'get.is.msisdn.27820001001'
+                            183, // 'post.is.msisdn.27820001001'
+                            204, // update identity cb245673-aa41-4302-ac47-00000001001
+                        ]
+                    })
+                    // dynamic fixture
+                    api.http.fixtures.add(fixtures_Pilot().not_exists({
+                        number: '+27123456789',
+                        address: '+27820001001',
+                        wait: true
+                    }));
+                })
                 .inputs.apply(this, JSON.parse(JSON.stringify(complexInputs)))
                 .check.user.answer("redial_sms_sent", true)
-                .check(function(api) {
-                    utils.check_fixtures_used(api, [4, 50, 116, 123, 174, 180, 183, 204]);
-                })
                 .run();
             });
         });
@@ -1042,6 +1083,25 @@ describe("app", function() {
                 it("should go to state_language", function() {
                     return tester
                     .setup.user.addr("27820001001")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                4, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                123, // create outbound message (clinic dialback)
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs.apply(this, setupInputs.concat('5101015009088')) // Add to the inputs for 'state_sa_id'
                     .check.interaction({
                         state: "state_language"
@@ -1110,6 +1170,25 @@ describe("app", function() {
                 it("should go to state_language", function() {
                     return tester
                     .setup.user.addr("27820001001")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                4, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                123, // create outbound message (clinic dialback)
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs.apply(this, setupInputs.concat(['12345'])) // Add to the inputs for 'state_passport_no'
                     .check.interaction({
                         state: "state_language"
@@ -1239,6 +1318,25 @@ describe("app", function() {
                     // 14 January 1981 is a valid date
                     return tester
                     .setup.user.addr("27820001001")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                4, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                123, // create outbound message (clinic dialback)
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs.apply(this, setupInputs.concat(['1', '14']))
                     .check.interaction({
                         state: "state_language"
@@ -1292,13 +1390,28 @@ describe("app", function() {
 
                     return tester
                     .setup.user.addr("27820001001")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                2, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                                187, // update identity cb245673-aa41-4302-ac47-00000001001
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs.apply(this, testInputs)
                     .check.interaction({
                         state: "state_end_success"
-                    })
-
-                    .check(function(api) {
-                        utils.check_fixtures_used(api, [2, 50, 116, 174, 180, 183, 187]);
                     })
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
@@ -1329,6 +1442,28 @@ describe("app", function() {
                 it("should go to state_end_success", function() {
                     return tester
                     .setup.user.addr("27820001003")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                3, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                52, // get active subscriptions for cb245673-aa41-4302-ac47-00000001003
+                                54, // get messagesets
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                182, // get identity by msisdn +27820001003
+                                183, // 'post.is.msisdn.27820001001'
+                                188, // update identity cb245673-aa41-4302-ac47-00000001001
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs(
                         {session_event: 'new'}  // dial in
                         , "2"  // state_start - no
@@ -1372,9 +1507,6 @@ describe("app", function() {
                         assert.deepEqual(metrics['test.ussd_clinic.registrations_started'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_clinic.avg.sessions_to_register'].values, [1]);
                     })
-                    .check(function(api) {
-                        utils.check_fixtures_used(api, [3, 50, 52, 54, 116, 174, 180, 182, 183, 188]);
-                    })
                     .check.reply.ends_session()
                     .run();
                 });
@@ -1391,6 +1523,25 @@ describe("app", function() {
 
                     return tester
                     .setup.user.addr("27820001001")
+                    .setup(function(api) {
+                        test_utils.only_use_fixtures(api, {
+                            numbers: [
+                                4, // register cb245673-aa41-4302-ac47-00000001001
+                                50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
+                                116, // 116: create outbound message for cb245673-aa41-4302-ac47-00000001001
+                                174, // Jembi Clinic Code validation - code 123456
+                                180, // 'get.is.msisdn.27820001001'
+                                183, // 'post.is.msisdn.27820001001'
+                                189, // update identity cb245673-aa41-4302-ac47-00000001001
+                            ]
+                        })
+                        // dynamic fixture
+                        api.http.fixtures.add(fixtures_Pilot().not_exists({
+                            number: '+27123456789',
+                            address: '+27820001001',
+                            wait: true
+                        }));
+                    })
                     .inputs.apply(this, testInputs)
                     .check.interaction({
                         state: "state_end_success"
@@ -1420,9 +1571,6 @@ describe("app", function() {
                         assert.deepEqual(metrics['test.ussd_clinic.state_language.no_complete.transient'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_clinic.registrations_started'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_clinic.avg.sessions_to_register'].values, [1]);
-                    })
-                    .check(function(api) {
-                        utils.check_fixtures_used(api, [4, 50, 116, 174, 180, 183, 189]);
                     })
                     .check.reply.ends_session()
                     .run();

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -364,7 +364,7 @@ describe("app", function() {
                                 183, // 'post.is.msisdn.27820001001'
                                 204, // update identity cb245673-aa41-4302-ac47-00000001001
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -572,7 +572,7 @@ describe("app", function() {
                             183, // 'post.is.msisdn.27820001001'
                             204, // update identity cb245673-aa41-4302-ac47-00000001001
                         ]
-                    })
+                    });
                     // dynamic fixture
                     api.http.fixtures.add(fixtures_Pilot().not_exists({
                         number: '+27123456789',
@@ -1094,7 +1094,7 @@ describe("app", function() {
                                 180, // 'get.is.msisdn.27820001001'
                                 183, // 'post.is.msisdn.27820001001'
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -1181,7 +1181,7 @@ describe("app", function() {
                                 180, // 'get.is.msisdn.27820001001'
                                 183, // 'post.is.msisdn.27820001001'
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -1329,7 +1329,7 @@ describe("app", function() {
                                 180, // 'get.is.msisdn.27820001001'
                                 183, // 'post.is.msisdn.27820001001'
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -1401,7 +1401,7 @@ describe("app", function() {
                                 183, // 'post.is.msisdn.27820001001'
                                 187, // update identity cb245673-aa41-4302-ac47-00000001001
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -1456,7 +1456,7 @@ describe("app", function() {
                                 183, // 'post.is.msisdn.27820001001'
                                 188, // update identity cb245673-aa41-4302-ac47-00000001001
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',
@@ -1534,7 +1534,7 @@ describe("app", function() {
                                 183, // 'post.is.msisdn.27820001001'
                                 189, // update identity cb245673-aa41-4302-ac47-00000001001
                             ]
-                        })
+                        });
                         // dynamic fixture
                         api.http.fixtures.add(fixtures_Pilot().not_exists({
                             number: '+27123456789',

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -1720,11 +1720,15 @@ describe("app", function() {
                 .setup.user.addr("27820001001")
                 .inputs.apply(this, sessionArgs)
                 .check.interaction({
-                    state: "state_pilot",
+                    state: "state_language",
                     reply: [
-                        'How would the pregnant mother like to receive the messages?',
-                        '1. WhatsApp',
-                        '2. SMS',
+                        'Please select the language that the mother would like to get messages in:',
+                        '1. isiZulu',
+                        '2. isiXhosa',
+                        '3. Afrikaans',
+                        '4. English',
+                        '5. Sesotho sa Leboa',
+                        '6. More'
                     ].join('\n')
                 })
                 .check(function (api, im, app) {
@@ -1813,8 +1817,7 @@ describe("app", function() {
                         }));
                 })
                 .setup.user.addr("27820001001")
-                // Add '1' for 'state_pilot - opt in'
-                .inputs.apply(this, sessionArgs.concat(['1']))
+                .inputs.apply(this, sessionArgs)
                 .check.interaction({
                     state: "state_language"
                 })
@@ -1858,18 +1861,16 @@ describe("app", function() {
                                 address: '+27820001001',
                                 wait: true
                         })),
-                        api.http.fixtures.add(
-                            fixtures_Pilot().patch_identity({
-                                identity: 'cb245673-aa41-4302-ac47-00000001001',
-                                address: '+27820001001',
-                                language: 'eng_ZA',
-                                details: {
-                                    clinic: {
-                                        redial_sms_sent: false
-                                    }
+                        api.http.fixtures.add(fixtures_Pilot().patch_identity({
+                            identity: 'cb245673-aa41-4302-ac47-00000001001',
+                            address: '+27820001001',
+                            language: 'eng_ZA',
+                            details: {
+                                clinic: {
+                                    redial_sms_sent: false
                                 }
                             }
-                        )),
+                        })),
                         api.http.fixtures.add(fixtures_Pilot().post_registration({
                             identity: 'cb245673-aa41-4302-ac47-00000001001',
                             address: '27820001001',
@@ -1896,8 +1897,8 @@ describe("app", function() {
                     ];
                 })
                 .setup.user.addr("27820001001")
-                // Add '1' for 'state_pilot - opt in', '4' for 'state_language - english'
-                .inputs.apply(this, sessionArgs.concat(['1', '4']))
+                // Add '4' for 'state_language - english'
+                .inputs.apply(this, sessionArgs.concat(['4']))
                 .check.interaction({
                     state: "state_end_success"
                 })


### PR DESCRIPTION
Currently we're requiring two opt-ins which is fairly counter intuitive and unnecessary.
The first opt in is whether they want to receive MomConnect messages, the second opt-in is whether they want to receive via SMS or WhatsApp.

I think we should collapse it into a single opt-in for MomConnect.
If the mother is WhatsAppable then default to WA, otherwise SMS.

The welcome message should make it very explicit on how the mother can change to WA or SMS.