### PR TITLE
Send identity optout to hub

### DIFF
--- a/go-app-ussd_popi_user_data.js
+++ b/go-app-ussd_popi_user_data.js
@@ -678,32 +678,30 @@ go.app = function() {
         });
 
         self.add('state_optout', function(name) {
+            var optout_info = {
+                "optout_type": "forget",
+                "identity": self.im.user.answers.operator.id,
+                "reason": "unknown",
+                "address_type": "msisdn",
+                "address": self.im.user.answers.operator_msisdn,
+                "request_source": self.im.config.name || "ussd_popi_user_data"
+            };
+
             return hub
             .create_change(
                 {
                     "registrant_id": self.im.user.answers.operator.id,
                     "action": "momconnect_nonloss_optout",
                     "data": {
-                        "reason": "unknown"
+                        "reason": "unknown",
+                        "identity_store_optout": optout_info
                     }
                 }
             )
             .then(function() {
-                var optout_info = {
-                    "optout_type": "forget",
-                    "identity": self.im.user.answers.operator.id,
-                    "reason": "unknown",
-                    "address_type": "msisdn",
-                    "address": self.im.user.answers.operator_msisdn,
-                    "request_source": self.im.config.name || "ussd_popi_user_data"
-                };
-                return is
-                .optout(optout_info)
-                .then(function() {
-                    self.im.user.set_answer("operator", null);
-                    self.im.user.set_answer("msisdn", null);
-                    return self.states.create('state_info_deleted');
-                });
+                self.im.user.set_answer("operator", null);
+                self.im.user.set_answer("msisdn", null);
+                return self.states.create('state_info_deleted');
             });
         });
 

--- a/go-app-ussd_popi_user_data.js
+++ b/go-app-ussd_popi_user_data.js
@@ -682,8 +682,8 @@ go.app = function() {
                 "optout_type": "forget",
                 "identity": self.im.user.answers.operator.id,
                 "reason": "unknown",
-                "address_type": "msisdn",
-                "address": self.im.user.answers.operator_msisdn,
+                "address_type": "",
+                "address": "",
                 "request_source": self.im.config.name || "ussd_popi_user_data"
             };
 

--- a/src/ussd_popi_user_data.js
+++ b/src/ussd_popi_user_data.js
@@ -675,32 +675,30 @@ go.app = function() {
         });
 
         self.add('state_optout', function(name) {
+            var optout_info = {
+                "optout_type": "forget",
+                "identity": self.im.user.answers.operator.id,
+                "reason": "unknown",
+                "address_type": "msisdn",
+                "address": self.im.user.answers.operator_msisdn,
+                "request_source": self.im.config.name || "ussd_popi_user_data"
+            };
+
             return hub
             .create_change(
                 {
                     "registrant_id": self.im.user.answers.operator.id,
                     "action": "momconnect_nonloss_optout",
                     "data": {
-                        "reason": "unknown"
+                        "reason": "unknown",
+                        "identity_store_optout": optout_info
                     }
                 }
             )
             .then(function() {
-                var optout_info = {
-                    "optout_type": "forget",
-                    "identity": self.im.user.answers.operator.id,
-                    "reason": "unknown",
-                    "address_type": "msisdn",
-                    "address": self.im.user.answers.operator_msisdn,
-                    "request_source": self.im.config.name || "ussd_popi_user_data"
-                };
-                return is
-                .optout(optout_info)
-                .then(function() {
-                    self.im.user.set_answer("operator", null);
-                    self.im.user.set_answer("msisdn", null);
-                    return self.states.create('state_info_deleted');
-                });
+                self.im.user.set_answer("operator", null);
+                self.im.user.set_answer("msisdn", null);
+                return self.states.create('state_info_deleted');
             });
         });
 

--- a/src/ussd_popi_user_data.js
+++ b/src/ussd_popi_user_data.js
@@ -679,8 +679,8 @@ go.app = function() {
                 "optout_type": "forget",
                 "identity": self.im.user.answers.operator.id,
                 "reason": "unknown",
-                "address_type": "msisdn",
-                "address": self.im.user.answers.operator_msisdn,
+                "address_type": "",
+                "address": "",
                 "request_source": self.im.config.name || "ussd_popi_user_data"
             };
 

--- a/test/fixtures_hub.js
+++ b/test/fixtures_hub.js
@@ -950,7 +950,15 @@ module.exports = function() {
                     "registrant_id": "cb245673-aa41-4302-ac47-00000001002",
                     "action": "momconnect_nonloss_optout",
                     "data": {
-                        "reason": "unknown"
+                        "reason": "unknown",
+                        "identity_store_optout": {
+                            "optout_type":"forget",
+                            "identity":"cb245673-aa41-4302-ac47-00000001002",
+                            "reason":"unknown",
+                            "address_type":"msisdn",
+                            "address":"+27820001002",
+                            "request_source":"ussd_popi_user_data"
+                        }
                     }
                 }
             },

--- a/test/fixtures_hub.js
+++ b/test/fixtures_hub.js
@@ -955,8 +955,8 @@ module.exports = function() {
                             "optout_type":"forget",
                             "identity":"cb245673-aa41-4302-ac47-00000001002",
                             "reason":"unknown",
-                            "address_type":"msisdn",
-                            "address":"+27820001002",
+                            "address_type":"",
+                            "address":"",
                             "request_source":"ussd_popi_user_data"
                         }
                     }

--- a/test/ussd_popi_user_data.test.js
+++ b/test/ussd_popi_user_data.test.js
@@ -1342,7 +1342,7 @@ describe('app', function() {
                             .check.user.answer("operator", null)
                             .check.user.answer("msisdn", null)
                             .check(function(api) {
-                                utils.check_fixtures_used(api, [41, 51, 54, 67, 121, 186, 194]);
+                                utils.check_fixtures_used(api, [41, 51, 54, 67, 121, 194]);
                             })
                             .run();
                         });


### PR DESCRIPTION
Part of this change: `https://github.com/praekeltfoundation/ndoh-hub/pull/160`.

Identity optout needs to go through the hub to insure that we send it to jembi before we remove the msisdn from the identity.