### PR TITLE
Default to WhatsApp registration for public USSD line

### DIFF
--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -262,8 +262,10 @@ go.app = function() {
                     //      Because of how Seed's services work using asynchronous webhooks there
                     //      can be a race condition if we check the subscriptions too soon after
                     //      creating a new registration
-                    if(self.im.user.answers.state_pilot == 'whatsapp') {
+                    if(self.im.user.answers.registered_on_whatsapp === true) {
                         return pilot_config.channel;
+                    } else if(self.im.user.answers.registered_on_whatsapp === false) {
+                        return self.im.config.services.message_sender.channel;
                     }
 
                     return sbm
@@ -415,7 +417,7 @@ go.app = function() {
             };
             var registration_info = {
                 "reg_type": (
-                    self.im.user.answers.state_pilot == 'whatsapp'
+                    self.im.user.answers.registered_on_whatsapp
                     ? "whatsapp_prebirth"
                     : "momconnect_prebirth"),
                 "registrant_id": self.im.user.answers.registrant.id,
@@ -727,9 +729,7 @@ go.app = function() {
                 })
                 .then(function(yes_or_no) {
                     self.im.user.set_answer('registered_on_whatsapp', yes_or_no);
-                    return yes_or_no
-                        ? self.states.create('state_pilot')
-                        : self.states.create('state_save_subscription');
+                    return self.states.create('state_save_subscription');
                 });
         });
 
@@ -742,18 +742,12 @@ go.app = function() {
             }
 
             var pilot_config = self.im.config.pilot || {};
-            var whitelist = pilot_config.whitelist || [];
-            var randomisation_threshold = pilot_config.randomisation_threshold || 0.0;
             var api_url = pilot_config.api_url;
             var api_token = pilot_config.api_token;
             var api_number = pilot_config.api_number;
 
             var msisdn = params.address;
 
-            // Always allow people on the whitelist
-            if(whitelist.indexOf(msisdn) > -1) {
-                return Q(true);
-            }
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
@@ -776,40 +770,15 @@ go.app = function() {
                                 return false;
                             });
                     } else {
-                        // Otherwise roll the dice
-                        var can_participate = Math.random() < randomisation_threshold;
+                        // Otherwise return true
                         return self.im
-                            .log(msisdn + ' is whatsappable, randomisation selected: ' + can_participate)
+                            .log(msisdn + ' is whatsappable')
                             .then(function() {
-                                return can_participate;
+                                return true;
                             });
                     }
                 });
         };
-
-        self.add('state_pilot', function(name) {
-            var pilot_config = self.im.config.pilot || {};
-            var nudge_threshold = pilot_config.nudge_threshold || 0.0;
-            var question = $('How would you like to receive messages about you and your baby?');
-            var whatsapp_label = $('WhatsApp');
-            var sms_label = $('SMS');
-
-            if(self.im.user.answers.state_language == 'eng_ZA' && Math.random() < nudge_threshold) {
-                question = "Would you prefer to receive messages about you and your baby via WhatsApp?";
-                whatsapp_label = 'Yes';
-                sms_label = 'No';
-            }
-
-            self.im.user.set_answer("state_pilot_question", self.im.user.i18n(question));
-            return new ChoiceState(name, {
-                question: question,
-                choices: [
-                    new Choice('whatsapp', whatsapp_label),
-                    new Choice('sms', sms_label),
-                ],
-                next: 'state_save_subscription'
-            });
-        });
 
         self.add('state_save_subscription', function(name) {  // interstitial state
             var registration_info = self.compile_registration_info();

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -436,20 +436,23 @@ go.app = function() {
         };
 
         self.send_registration_thanks = function() {
-            return self
-                .get_channel()
-                .then(function(channel) {
-                    return ms.
-                        create_outbound(
-                            self.im.user.answers.registrant.id,
-                            self.im.user.answers.registrant_msisdn,
-                            self.im.user.i18n($(
-                                "Congratulations on your pregnancy. You will now get free messages about MomConnect. " +
-                                "You can register for the full set of FREE helpful messages at a clinic."
-                            )), {
-                                channel: channel
-                            });
-                });
+            var whatsapp_content = self.im.user.i18n($(
+                "Welcome! MomConnect sends msgs on WhatsApp for 3 wks. Visit a clinic for more msgs. " +
+                'To stop dial {{optout_channel}}. To get msgs in SMS, reply "SMS" (std rates apply)'
+            ).context({
+                optout_channel: self.im.config.optout_channel
+            }));
+            var sms_content = self.im.user.i18n($(
+                "Welcome! MomConnect will send msgs on SMS for 3 wks. Visit a clinic for more msgs. " +
+                "To stop dial {{optout_channel}}."
+            ).context({
+                optout_channel: self.im.config.optout_channel
+            }));
+            return ms.create_outbound(
+                self.im.user.answers.registrant.id,
+                self.im.user.answers.registrant_msisdn,
+                self.im.user.answers.registered_on_whatsapp ? whatsapp_content : sms_content
+            );
         };
 
         self.send_compliment_instructions = function() {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -795,10 +795,19 @@ go.app = function() {
         });
 
         self.add('state_end_success', function(name) {
+            var msisdn = self.im.user.answers.registrant_msisdn.replace("+27", "0");
+            var whatsapp_content = $(
+                "You're done! This number {{msisdn}} will get helpful messages from MomConnect on WhatsApp. " +
+                "For the full set of messages, register at a clinic.").context({
+                    msisdn: msisdn
+                });
+            var sms_content = $(
+                "You're done! This number {{msisdn}} will get helpful messages from MomConnect on SMS. " +
+                "You can register for the full set of FREE messages at a clinic.").context({
+                    msisdn: msisdn
+                });
             return new EndState(name, {
-                text: $('Congratulations on your pregnancy. You will now get free messages ' +
-                        'about MomConnect. You can register for the full set of FREE ' +
-                        'helpful messages at a clinic.'),
+                text: self.im.user.answers.registered_on_whatsapp ? whatsapp_content : sms_content,
                 next: 'state_start'
             });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -645,10 +645,19 @@ go.app = function() {
         });
 
         self.add('state_end_success', function(name) {
+            var msisdn = self.im.user.answers.registrant_msisdn.replace("+27", "0");
+            var whatsapp_content = $(
+                "You're done! This number {{msisdn}} will get helpful messages from MomConnect on WhatsApp. " +
+                "For the full set of messages, register at a clinic.").context({
+                    msisdn: msisdn
+                });
+            var sms_content = $(
+                "You're done! This number {{msisdn}} will get helpful messages from MomConnect on SMS. " +
+                "You can register for the full set of FREE messages at a clinic.").context({
+                    msisdn: msisdn
+                });
             return new EndState(name, {
-                text: $('Congratulations on your pregnancy. You will now get free messages ' +
-                        'about MomConnect. You can register for the full set of FREE ' +
-                        'helpful messages at a clinic.'),
+                text: self.im.user.answers.registered_on_whatsapp ? whatsapp_content : sms_content,
                 next: 'state_start'
             });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -286,20 +286,23 @@ go.app = function() {
         };
 
         self.send_registration_thanks = function() {
-            return self
-                .get_channel()
-                .then(function(channel) {
-                    return ms.
-                        create_outbound(
-                            self.im.user.answers.registrant.id,
-                            self.im.user.answers.registrant_msisdn,
-                            self.im.user.i18n($(
-                                "Congratulations on your pregnancy. You will now get free messages about MomConnect. " +
-                                "You can register for the full set of FREE helpful messages at a clinic."
-                            )), {
-                                channel: channel
-                            });
-                });
+            var whatsapp_content = self.im.user.i18n($(
+                "Welcome! MomConnect sends msgs on WhatsApp for 3 wks. Visit a clinic for more msgs. " +
+                'To stop dial {{optout_channel}}. To get msgs in SMS, reply "SMS" (std rates apply)'
+            ).context({
+                optout_channel: self.im.config.optout_channel
+            }));
+            var sms_content = self.im.user.i18n($(
+                "Welcome! MomConnect will send msgs on SMS for 3 wks. Visit a clinic for more msgs. " +
+                "To stop dial {{optout_channel}}."
+            ).context({
+                optout_channel: self.im.config.optout_channel
+            }));
+            return ms.create_outbound(
+                self.im.user.answers.registrant.id,
+                self.im.user.answers.registrant_msisdn,
+                self.im.user.answers.registered_on_whatsapp ? whatsapp_content : sms_content
+            );
         };
 
         self.send_compliment_instructions = function() {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -112,8 +112,10 @@ go.app = function() {
                     //      Because of how Seed's services work using asynchronous webhooks there
                     //      can be a race condition if we check the subscriptions too soon after
                     //      creating a new registration
-                    if(self.im.user.answers.state_pilot == 'whatsapp') {
+                    if(self.im.user.answers.registered_on_whatsapp === true) {
                         return pilot_config.channel;
+                    } else if(self.im.user.answers.registered_on_whatsapp === false) {
+                        return self.im.config.services.message_sender.channel;
                     }
 
                     return sbm
@@ -265,7 +267,7 @@ go.app = function() {
             };
             var registration_info = {
                 "reg_type": (
-                    self.im.user.answers.state_pilot == 'whatsapp'
+                    self.im.user.answers.registered_on_whatsapp
                     ? "whatsapp_prebirth"
                     : "momconnect_prebirth"),
                 "registrant_id": self.im.user.answers.registrant.id,
@@ -577,9 +579,7 @@ go.app = function() {
                 })
                 .then(function(yes_or_no) {
                     self.im.user.set_answer('registered_on_whatsapp', yes_or_no);
-                    return yes_or_no
-                        ? self.states.create('state_pilot')
-                        : self.states.create('state_save_subscription');
+                    return self.states.create('state_save_subscription');
                 });
         });
 
@@ -592,18 +592,12 @@ go.app = function() {
             }
 
             var pilot_config = self.im.config.pilot || {};
-            var whitelist = pilot_config.whitelist || [];
-            var randomisation_threshold = pilot_config.randomisation_threshold || 0.0;
             var api_url = pilot_config.api_url;
             var api_token = pilot_config.api_token;
             var api_number = pilot_config.api_number;
 
             var msisdn = params.address;
 
-            // Always allow people on the whitelist
-            if(whitelist.indexOf(msisdn) > -1) {
-                return Q(true);
-            }
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
@@ -626,40 +620,15 @@ go.app = function() {
                                 return false;
                             });
                     } else {
-                        // Otherwise roll the dice
-                        var can_participate = Math.random() < randomisation_threshold;
+                        // Otherwise return true
                         return self.im
-                            .log(msisdn + ' is whatsappable, randomisation selected: ' + can_participate)
+                            .log(msisdn + ' is whatsappable')
                             .then(function() {
-                                return can_participate;
+                                return true;
                             });
                     }
                 });
         };
-
-        self.add('state_pilot', function(name) {
-            var pilot_config = self.im.config.pilot || {};
-            var nudge_threshold = pilot_config.nudge_threshold || 0.0;
-            var question = $('How would you like to receive messages about you and your baby?');
-            var whatsapp_label = $('WhatsApp');
-            var sms_label = $('SMS');
-
-            if(self.im.user.answers.state_language == 'eng_ZA' && Math.random() < nudge_threshold) {
-                question = "Would you prefer to receive messages about you and your baby via WhatsApp?";
-                whatsapp_label = 'Yes';
-                sms_label = 'No';
-            }
-
-            self.im.user.set_answer("state_pilot_question", self.im.user.i18n(question));
-            return new ChoiceState(name, {
-                question: question,
-                choices: [
-                    new Choice('whatsapp', whatsapp_label),
-                    new Choice('sms', sms_label),
-                ],
-                next: 'state_save_subscription'
-            });
-        });
 
         self.add('state_save_subscription', function(name) {  // interstitial state
             var registration_info = self.compile_registration_info();

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -6,6 +6,7 @@ var fixtures_IdentityStore = require('./fixtures_identity_store');
 var fixtures_IdentityStoreDynamic = require('./fixtures_identity_store_dynamic')();
 var fixtures_StageBasedMessaging = require('./fixtures_stage_based_messaging');
 var fixtures_MessageSender = require('./fixtures_message_sender');
+var fixtures_MessageSenderDynamic = require('./fixtures_message_sender_dynamic')();
 var fixtures_Hub = require('./fixtures_hub');
 var fixtures_HubDynamic = require('./fixtures_hub_dynamic')();
 var fixtures_Jembi = require('./fixtures_jembi');
@@ -38,6 +39,7 @@ describe("ussd_public app", function() {
                         "state_end_success", "state_registered_full", "state_registered_not_full",
                         "state_end_compliment", "state_end_complaint", "state_end_go_clinic"],
                     channel: "*120*550#",
+                    optout_channel: "*120*550*1#",
                     services: {
                         identity_store: {
                             url: 'http://is/api/v1/',
@@ -116,6 +118,16 @@ describe("ussd_public app", function() {
         describe("test avg.sessions_to_register metric", function() {
             it("should increment metric according to number of sessions", function() {
                 return tester
+                    .setup(function(api){
+                        api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                            to_identity: 'cb245673-aa41-4302-ac47-00000001001',
+                            to_addr: '+27820001001',
+                            content: (
+                                "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                                "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                            )
+                        }));
+                    })
                     .setup.user.addr('27820001001')
                     .inputs(
                         {session_event: "new"}
@@ -134,7 +146,7 @@ describe("ussd_public app", function() {
                         assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [2]);
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                        utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -266,6 +278,16 @@ describe("ussd_public app", function() {
             });
             it("don't send when timeout occurs on a non-dialback state", function() {
                 return tester
+                .setup(function(api){
+                    api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                        to_identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        to_addr: '+27820001001',
+                        content: (
+                            "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                            "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                        )
+                    }));
+                })
                 .setup.user.addr("27820001001")
                 .inputs(
                     {session_event: 'new'}  // dial in
@@ -278,12 +300,22 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", false)  // session closed on non-dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                    utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
                 })
                 .run();
             });
             it("updates identity with redial_sms_sent 'true'", function() {
                 return tester
+                .setup(function(api){
+                    api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                        to_identity: 'cb245673-aa41-4302-ac47-00000001001',
+                        to_addr: '+27820001001',
+                        content: (
+                            "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                            "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                        )
+                    }));
+                })
                 .setup.user.addr("27820001001")
                 .inputs(
                     {session_event: 'new'}  // dial in
@@ -296,7 +328,7 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)  // session closed on dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 50, 117, 125, 180, 183, 208]);
+                    utils.check_fixtures_used(api, [17, 50, 125, 180, 183, 208, 252]);
                 })
                 .run();
             });
@@ -509,6 +541,16 @@ describe("ussd_public app", function() {
                 describe("if the number was not opted out", function() {
                     it("should go to state_end_success", function() {
                         return tester
+                        .setup(function(api){
+                            api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                                to_identity: 'cb245673-aa41-4302-ac47-00000001001',
+                                to_addr: '+27820001001',
+                                content: (
+                                    "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                                    "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                                )
+                            }));
+                        })
                         .setup.user.addr("27820001001")
                         .inputs(
                             {session_event: "new"}
@@ -525,7 +567,7 @@ describe("ussd_public app", function() {
                             assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [1]);
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [17, 117, 180, 183, 198]);
+                            utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -583,6 +625,16 @@ describe("ussd_public app", function() {
             describe("choosing to opt in", function() {
                 it("should go to state_end_success", function() {
                     return tester
+                    .setup(function(api){
+                        api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                            to_identity: 'cb245673-aa41-4302-ac47-00000001004',
+                            to_addr: '+27820001004',
+                            content: (
+                                "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                                "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                            )
+                        }));
+                    })
                     .setup.user.addr("27820001004")
                     .inputs(
                         {session_event: "new"}
@@ -595,7 +647,7 @@ describe("ussd_public app", function() {
                         state: "state_end_success"
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [18, 118, 184, 199, 238]);
+                        utils.check_fixtures_used(api, [18, 184, 199, 238, 252]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -716,6 +768,7 @@ describe("ussd_public app", function() {
                         "state_end_success", "state_registered_full", "state_registered_not_full",
                         "state_end_compliment", "state_end_complaint", "state_end_go_clinic"],
                     channel: "*120*550#",
+                    optout_channel: "*120*550*1#",
                     services: {
                         identity_store: {
                             url: 'http://is/api/v1/',
@@ -801,8 +854,11 @@ describe("ussd_public app", function() {
                     api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
                         identity: 'cb245673-aa41-4302-ac47-00000001001',
                         address: '+27820001001',
-                        channel: 'pilot-channel',
-                        content: 'Congratulations on your pregnancy. You will now get free messages about MomConnect. You can register for the full set of FREE helpful messages at a clinic.'
+                        channel: 'default-channel',
+                        content: (
+                            "Welcome! MomConnect sends msgs on WhatsApp for 3 wks. Visit a clinic for more msgs. " +
+                            'To stop dial *120*550*1#. To get msgs in SMS, reply "SMS" (std rates apply)'
+                        )
                     }));
                 })
                 .setup.user.addr("27820001001")
@@ -916,7 +972,10 @@ describe("ussd_public app", function() {
                         identity: 'cb245673-aa41-4302-ac47-00000001001',
                         address: '+27820001001',
                         channel: 'default-channel',
-                        content: 'Congratulations on your pregnancy. You will now get free messages about MomConnect. You can register for the full set of FREE helpful messages at a clinic.'
+                        content: (
+                            "Welcome! MomConnect will send msgs on SMS for 3 wks. " +
+                            "Visit a clinic for more msgs. To stop dial *120*550*1#."
+                        )
                     }));
                 })
                 .setup.user.addr("27820001001")

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -128,9 +128,6 @@ describe("ussd_public app", function() {
                     )
                     .check.interaction({
                         state: "state_end_success",
-                        reply: 'Congratulations on your pregnancy. You will now get free messages ' +
-                               'about MomConnect. You can register for the full set of FREE ' +
-                               'helpful messages at a clinic.'
                     })
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
@@ -521,9 +518,6 @@ describe("ussd_public app", function() {
                         )
                         .check.interaction({
                             state: "state_end_success",
-                            reply: 'Congratulations on your pregnancy. You will now get free messages ' +
-                                   'about MomConnect. You can register for the full set of FREE ' +
-                                   'helpful messages at a clinic.'
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
@@ -764,67 +758,6 @@ describe("ussd_public app", function() {
                 });
         });
 
-        it('should not trigger the pilot when number check returns false', function() {
-            return tester
-                .setup(function(api) {
-                    // randomisation will always returns True but the check API will deny it
-                    // before it gets there
-                    var pilot_config = api.config.store.config.pilot;
-                    pilot_config.randomisation_threshold = 1.0;
-                    test_utils.only_use_fixtures(api, {
-                        numbers: [
-                            180, // 'get.is.msisdn.27820001001'
-                            183, // 'post.is.msisdn.27820001001'
-                            198, // 'patch.is.identity.cb245673-aa41-4302-ac47-00000001001'
-                            50, // 'get.sbm.identity.cb245673-aa41-4302-ac47-00000001001'
-                            117, // 'post.ms.outbound.27820001001'
-                        ],
-                    });
-                    api.http.fixtures.add(
-                        fixtures_Pilot().not_exists({
-                            number: '+27123456789',
-                            address: '+27820001001',
-                            wait: false,
-                        }));
-
-                    api.http.fixtures.add(
-                        fixtures_Pilot().not_exists({
-                            number: '+27123456789',
-                            address: '+27820001001',
-                            wait: true,
-                        }));
-                    api.http.fixtures.add(fixtures_Pilot().post_registration({
-                        identity: 'cb245673-aa41-4302-ac47-00000001001',
-                        address: '27820001001',
-                        reg_type: 'momconnect_prebirth',
-                        language: 'zul_ZA',
-                        consent: true,
-                        data: {
-                            registered_on_whatsapp: false
-                        }
-                    }));
-                    api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
-                        identity: 'cb245673-aa41-4302-ac47-00000001001',
-                        address: '+27820001001',
-                        channel: 'default-channel',
-                        content: 'Congratulations on your pregnancy. You will now get free messages about MomConnect. You can register for the full set of FREE helpful messages at a clinic.',
-                    }));
-                })
-                .setup.user.addr("27820001001")
-                .inputs(
-                    {session_event: "new"}
-                    , "1"  // state_language - zul_ZA
-                    , "1"  // state_suspect_pregnancy - yes
-                    , "1"  // state_consent - yes
-                )
-                .check.interaction({
-                    state: "state_end_success",
-                    reply: /Congratulations on your pregnancy./
-                })
-                .check.reply.ends_session()
-                .run();
-        });
-
         it('should submit pilot reg_type if participating in the pilot', function () {
             return tester
                 .setup(function(api) {
@@ -888,7 +821,10 @@ describe("ussd_public app", function() {
                 .input('1')
                 .check.interaction({
                     state: "state_end_success",
-                    reply: /Congratulations on your pregnancy/
+                    reply: (
+                        "You're done! This number 0820001001 will get helpful messages from MomConnect on WhatsApp. " +
+                        "For the full set of messages, register at a clinic."
+                    )
                 })
                 .check.reply.ends_session()
                 .run();
@@ -999,7 +935,10 @@ describe("ussd_public app", function() {
                 .input('1')
                 .check.interaction({
                     state: "state_end_success",
-                    reply: /Congratulations on your pregnancy/
+                    reply: (
+                        "You're done! This number 0820001001 will get helpful messages from MomConnect on SMS. " +
+                        "You can register for the full set of FREE messages at a clinic."
+                    )
                 })
                 .check.reply.ends_session()
                 .run();


### PR DESCRIPTION
This PR removes the channel selection screen, defaulting to WhatsApp if the check returns true, otherwise defaulting to SMS.

It changes the content of the registration confirmation screen, and makes it channel specific.

It changes the content of the welcome SMS, and makes it channel specific.