### PR TITLE
Change PMTCT reg channel to be the same as existing registration

### DIFF
--- a/go-app-ussd_pmtct_seed.js
+++ b/go-app-ussd_pmtct_seed.js
@@ -62,12 +62,6 @@ go.app = function() {
         self.get_channel = function() {
             var pilot_config = self.im.config.pilot || {};
             return Q()
-                .then(function() {
-                    return self.im.log([
-                        'pilot_state: ' + self.im.user.answers.state_create_pmtct_registration,
-                        'pilot config: ' + JSON.stringify(pilot_config),
-                    ].join('\n'));
-                })
                 .then(function () {
                     // NOTE:
                     //      If we're able to tell from local state what channel is supposed to be
@@ -75,21 +69,11 @@ go.app = function() {
                     //      Because of how Seed's services work using asynchronous webhooks there
                     //      can be a race condition if we check the subscriptions too soon after
                     //      creating a new registration
-                    if(self.im.user.answers.state_register_pmtct === 'whatsapp') {
+                    if(self.im.user.answers.channel === 'whatsapp') {
                         return pilot_config.channel;
                     } else {
                         return self.im.config.services.message_sender.channel;
                     }
-
-                    return sbm
-                        .is_identity_subscribed(self.im.user.answers.identity.id, [/whatsapp/])
-                        .then(function(confirmed) {
-                            if(confirmed) {
-                                return pilot_config.channel;
-                            } else {
-                                return self.im.config.services.message_sender.channel;
-                            }
-                        });
                 })
                 .then(function(channel) {
                     return self.im
@@ -175,7 +159,6 @@ go.app = function() {
                 } else if (log_mode === 'test') {
                     return Q()
                     .then(function() {
-                        console.log("Running: " + name);
                         return creator(name, opts);
                     });
                 } else if (log_mode === 'off' || null) {
@@ -191,19 +174,7 @@ go.app = function() {
 
         self.add("state_start", function(name) {
             self.im.user.answers = {};  // reset answers
-            var address = utils.normalize_msisdn(self.im.user.addr, '27');
-            // NOTE:    We're making the API call here but not telling it to wait nor are we doing
-            //          anything with the result.
-            //
-            //          The idea is that the check continues to happen in the background and will be ready
-            //          when we need it. This way we minimise any timeout penalty during the registration.
-            return self
-                .is_valid_recipient_for_pilot({
-                    address: address,
-                    wait: false
-                }).then(function(res) {
-                    return self.states.create("state_check_pmtct_subscription");
-                });
+            return self.states.create("state_check_pmtct_subscription");
         });
 
         // interstitial
@@ -221,7 +192,7 @@ go.app = function() {
                 self.im.user.set_answer("identity", identity);
                 return self.im.user
                 .set_lang(self.im.user.answers.identity.details.lang_code || "eng_ZA")
-                .then(function(lang_set_response) {
+                .then(function() {
                     return sbm
                     .list_active_subscriptions(identity.id)
                     .then(function(active_subs_response) {
@@ -308,6 +279,13 @@ go.app = function() {
                                         // Default to prebirth if multiple subscriptions
                                         self.im.user.set_answer("subscription_type", "prebirth");
                                     }
+
+                                    if (whatsapp_postbirth_subscription || whatsapp_prebirth_subscription) {
+                                        self.im.user.set_answer("channel", "whatsapp");
+                                    } else {
+                                        self.im.user.set_answer("channel", "sms");
+                                    }
+
                                     return self.states.create("state_route");
                                 } else {
                                     return self.states.create("state_end_not_registered");
@@ -432,36 +410,13 @@ go.app = function() {
                 next: function(choice) {
                     if (choice.value === "yes") {
                         self.im.user.set_answer("hiv_opt_in", "true");
-                        return "state_register_pmtct";
+                        return "state_create_pmtct_registration";
                     } else {
                         self.im.user.set_answer("hiv_opt_in", "false");
                         return "state_end_hiv_messages_declined";
                     }
                 }
             });
-        });
-
-        self.add("state_register_pmtct", function(name) {
-            var address = utils.normalize_msisdn(self.im.user.addr, '27');
-            return self
-                .is_valid_recipient_for_pilot({
-                    address: address,
-                    wait: true
-                }).then(function(is_valid) {
-                    if (is_valid) {
-                        return new ChoiceState(name, {
-                            question: $(
-                                "Would you like to receive these messages over WhatsApp or SMS?"),
-                            choices: [
-                                new Choice('whatsapp', $("WhatsApp")),
-                                new Choice('sms', $("SMS"))
-                            ],
-                            next: 'state_create_pmtct_registration'
-                        });
-                    } else {
-                        return self.states.create('state_create_pmtct_registration');
-                    }
-                });
         });
 
         self.add("state_create_pmtct_registration", function(name) {
@@ -499,7 +454,7 @@ go.app = function() {
                         }
                     };
                 }
-                if (self.im.user.get_answer('state_register_pmtct') === 'whatsapp') {
+                if (self.im.user.get_answer('channel') === 'whatsapp') {
                     reg_info.reg_type = 'whatsapp_' + reg_info.reg_type;
                 }
                 return Q.all([

--- a/test/ussd_pmtct_seed.test.js
+++ b/test/ussd_pmtct_seed.test.js
@@ -238,14 +238,13 @@ describe("PMTCT app", function() {
                             , "4"  // state_birth_month
                             , "26"  // state_birth_day
                             , "1"  // state_hiv_messages - yes
-                            , "2"  // state_register_pmtct - sms
                         )
                         .check.interaction({
                             state: "state_end_hiv_messages_confirm",
                             reply: "You will now start receiving messages about keeping your child HIV-negative. Thank you for using the MomConnect service. Goodbye."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [27, 54, 60, 133, 134, 210, 215, 252, 253]);
+                            utils.check_fixtures_used(api, [27, 54, 60, 133, 134, 210, 215]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -363,14 +362,13 @@ describe("PMTCT app", function() {
                             , "4"  // state_birth_month - apr
                             , "26"  // state_birth_day
                             , "1"  // state_hiv_messages - yes
-                            , "2"  // state_register_pmtct - sms
                         )
                         .check.interaction({
                             state: "state_end_hiv_messages_confirm",
                             reply: "You will now start receiving messages about keeping your child HIV-negative. Thank you for using the MomConnect service. Goodbye."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [28, 54, 61, 135, 136, 211, 216, 254, 255]);
+                            utils.check_fixtures_used(api, [28, 54, 61, 135, 136, 211, 216]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -463,14 +461,13 @@ describe("PMTCT app", function() {
                             {session_event: "new"}  // dial in
                             , "1"  // state_consent - yes
                             , "1"  // state_hiv_messages - yes
-                            , "2"  // state_register_pmtct - sms
                         )
                         .check.interaction({
                             state: "state_end_hiv_messages_confirm",
                             reply: "You will now start receiving messages about keeping your child HIV-negative. Thank you for using the MomConnect service. Goodbye."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [29, 54, 62, 137, 138, 212, 217, 254, 255]);
+                            utils.check_fixtures_used(api, [29, 54, 62, 137, 138, 212, 217]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -531,14 +528,13 @@ describe("PMTCT app", function() {
                         .inputs(
                             {session_event: "new"}  // dial in
                             , "1"  // state_hiv_messages - yes
-                            , "2"  // state_register_pmtct - sms
                         )
                         .check.interaction({
                             state: "state_end_hiv_messages_confirm",
                             reply: "You will now start receiving messages about keeping your child HIV-negative. Thank you for using the MomConnect service. Goodbye."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [30, 54, 63, 139, 140, 213, 218, 254, 255]);
+                            utils.check_fixtures_used(api, [30, 54, 63, 139, 140, 213, 218]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -565,7 +561,7 @@ describe("PMTCT app", function() {
                             reply: "You need to be registered on MomConnect to receive these messages. Please visit the nearest clinic to register."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [64, 214, 254]);
+                            utils.check_fixtures_used(api, [64, 214]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -592,7 +588,7 @@ describe("PMTCT app", function() {
                             reply: "You need to be registered on MomConnect to receive these messages. Please visit the nearest clinic to register."
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [219, 254]);
+                            utils.check_fixtures_used(api, [219]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -652,7 +648,7 @@ describe("PMTCT app", function() {
                         reply: "You will not receive SMSs about keeping your baby HIV negative. You will still receive MomConnect SMSs. To stop receiving these SMSs, dial *134*550*1#"
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [32, 54, 65, 220, 252]);
+                        utils.check_fixtures_used(api, [32, 54, 65, 220]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -695,7 +691,7 @@ describe("PMTCT app", function() {
                         reply: "Thank you. You will no longer receive any messages from MomConnect. If you have any medical concerns, please visit your nearest clinic."
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [31, 54, 65, 220, 252]);
+                        utils.check_fixtures_used(api, [31, 54, 65, 220]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -713,113 +709,17 @@ describe("PMTCT app", function() {
                         reply: "Thank you. You will receive support messages from MomConnect in the coming weeks."
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [33, 54, 65, 220, 252]);
+                        utils.check_fixtures_used(api, [33, 54, 65, 220]);
                     })
                     .check.reply.ends_session()
                     .run();
             });
         });
         describe("PMTCT messages over pilot", function() {
-            it("user should not be given choice if they are not a valid recipient", function() {
+            it("user should be subscribed to the whatsapp message set if they are already on WhatsApp", function() {
                 return tester
                     .setup(function(api) {
                         api.http.fixtures.fixtures = [];
-                        api.http.fixtures.add(fixtures_Pilot().not_exists({
-                            number: '+27123456789',
-                            address: '+27820000111',
-                            wait: true
-                        }));
-                        api.http.fixtures.add(fixtures_Pilot().patch_identity({
-                            identity: 'cb245673-aa41-4302-ac47-00000000001',
-                            address: '+27820000111',
-                            language: 'eng_ZA',
-                            details: {
-                                pmtct: {
-                                    lang_code: 'eng_ZA'
-                                }
-                            }
-                        }));
-                        api.http.fixtures.add(fixtures_Pilot().post_registration({
-                            identity: 'cb245673-aa41-4302-ac47-00000000001',
-                            language: 'eng_ZA',
-                            reg_type: 'pmtct_prebirth',
-                            data: {
-                                'mom_dob': '1981-01-14',
-                                'edd': '2014-05-10'
-                            }
-                        }));
-                        api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
-                            identity: 'cb245673-aa41-4302-ac47-00000000001',
-                            content: 'HIV positive moms can have an HIV negative baby! You can get free medicine at the clinic to protect your baby and improve your health',
-                            channel: 'default-channel'
-                        }));
-                        api.http.fixtures.add(fixtures_Pilot().post_outbound_message({
-                            identity: 'cb245673-aa41-4302-ac47-00000000001',
-                            content: 'Recently tested HIV positive? You are not alone, many other pregnant women go through this. Visit b-wise.mobi or call the AIDS Helpline 0800 012 322',
-                            channel: 'default-channel'
-                        }));
-                    })
-                    .setup.user.answer('identity', {
-                        url: 'http://is/api/v1/identities/cb245673-aa41-4302-ac47-00000000001/',
-                        id: 'cb245673-aa41-4302-ac47-00000000001',
-                        version: 1,
-                        details: {
-                            default_addr_type: 'msisdn',
-                            addresses: {
-                                msisdn: {
-                                    '+27820000111': {default: true}
-                                }
-                            },
-                            lang_code: 'eng_ZA',
-                            source: 'clinic',
-                            last_mc_reg_on: 'clinic',
-                            last_edd: '2014-05-10'
-                        },
-                        created_at: "2016-08-05T06:13:29.693272Z",
-                        updated_at: "2016-08-05T06:13:29.693298Z"
-                    })
-                    .setup.user.answer('mom_dob', '1981-01-14')
-                    .setup.user.answer('consent', true)
-                    .setup.user.answer('subscription_type', 'prebirth')
-                    .setup.user.addr('0820000111')
-                    .setup.user.state('state_register_pmtct')
-                    .check.interaction({
-                        state: 'state_end_hiv_messages_confirm'
-                    })
-                    .run();
-            });
-
-            it("user should be given choice if they are a valid recipient", function() {
-                return tester
-                    .setup(function(api) {
-                        api.http.fixtures.fixtures = [];
-                        api.http.fixtures.add(fixtures_Pilot().exists({
-                            number: '+27123456789',
-                            address: '+27820000111',
-                            wait: true
-                        }));
-                    })
-                    .setup.user.addr('0820000111')
-                    .setup.user.state('state_register_pmtct')
-                    .check.interaction({
-                        state: 'state_register_pmtct',
-                        reply: [
-                            'Would you like to receive these messages over WhatsApp or SMS?',
-                            '1. WhatsApp',
-                            '2. SMS'].join('\n')
-                    })
-                    .run();
-            });
-
-            it("user should be subscribed to the pilot message set if they select that option", function() {
-                return tester
-                    .setup(function(api) {
-                        api.http.fixtures.fixtures = [];
-                        api.http.fixtures.add(fixtures_Pilot().exists({
-                            number: '+27123456789',
-                            address: '+27820000111',
-                            wait: true
-                        }));
                         api.http.fixtures.add(fixtures_Pilot().patch_identity({
                             identity: 'cb245673-aa41-4302-ac47-00000000001',
                             address: '+27820000111',
@@ -872,9 +772,10 @@ describe("PMTCT app", function() {
                     .setup.user.answer('mom_dob', '1981-01-14')
                     .setup.user.answer('consent', true)
                     .setup.user.answer('subscription_type', 'prebirth')
+                    .setup.user.answer('channel', 'whatsapp')
                     .setup.user.addr('0820000111')
-                    .setup.user.state('state_register_pmtct')
-                    .input('1')
+                    .setup.user.state('state_create_pmtct_registration')
+                    .start()
                     .check.interaction({
                         state: 'state_end_hiv_messages_confirm'
                     })


### PR DESCRIPTION
This PR changes the SEED PMTCT USSD line to create a PMTCT registration for the same channel as the user's current subscription is on.