### PR TITLE
add user-agents to API calls

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -677,6 +677,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Clinic',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/go-app-ussd_nurse.js
+++ b/go-app-ussd_nurse.js
@@ -183,6 +183,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Nurse',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/go-app-ussd_nurse_rapidpro.js
+++ b/go-app-ussd_nurse_rapidpro.js
@@ -12,6 +12,7 @@ go.RapidPro = function() {
         self.base_url = base_url;
         self.auth_token = auth_token;
         self.json_api.defaults.headers.Authorization = ['Token ' + self.auth_token];
+        self.json_api.defaults.headers['User-Agent'] = ['NDoH-JSBox/RapidPro'];
 
         self.get_contact = function(filters) {
             filters = filters || {};
@@ -211,6 +212,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/NurseRapidPro',
                     'Authorization': ['Bearer ' + token]
                 }})
                 .post(api_url + '/v1/contacts', {

--- a/go-app-ussd_pmtct_seed.js
+++ b/go-app-ussd_pmtct_seed.js
@@ -123,6 +123,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/USSDPmtctSeed',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/go-app-ussd_popi_user_data.js
+++ b/go-app-ussd_popi_user_data.js
@@ -182,6 +182,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/USSDPopiUserData',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -754,6 +754,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Public',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/src/rapidpro.js
+++ b/src/rapidpro.js
@@ -9,6 +9,7 @@ go.RapidPro = function() {
         self.base_url = base_url;
         self.auth_token = auth_token;
         self.json_api.defaults.headers.Authorization = ['Token ' + self.auth_token];
+        self.json_api.defaults.headers['User-Agent'] = ['NDoH-JSBox/RapidPro'];
 
         self.get_contact = function(filters) {
             filters = filters || {};

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -527,6 +527,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Clinic',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/src/ussd_nurse.js
+++ b/src/ussd_nurse.js
@@ -180,6 +180,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Nurse',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/src/ussd_nurse_rapidpro.js
+++ b/src/ussd_nurse_rapidpro.js
@@ -52,6 +52,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/NurseRapidPro',
                     'Authorization': ['Bearer ' + token]
                 }})
                 .post(api_url + '/v1/contacts', {

--- a/src/ussd_pmtct_seed.js
+++ b/src/ussd_pmtct_seed.js
@@ -120,6 +120,7 @@ go.app = function() {
 
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/USSDPmtctSeed',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/src/ussd_popi_user_data.js
+++ b/src/ussd_popi_user_data.js
@@ -179,6 +179,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/USSDPopiUserData',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -604,6 +604,7 @@ go.app = function() {
             // Otherwise check the API
             return new JsonApi(self.im, {
                 headers: {
+                    'User-Agent': 'NDoH-JSBox/Public',
                     'Authorization': ['Token ' + api_token]
                 }})
                 .post(api_url, {


### PR DESCRIPTION
Adding this allows us to identify still using Wassup by looking at the logs and spotting the user-agents.