### PR TITLE
Move contact check to Engage API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
                 ussd_clinic: [
                     'src/index.js',
                     'src/session_length_helper.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_clinic %>',
                     'src/init.js'
                 ],
@@ -132,6 +133,7 @@ module.exports = function (grunt) {
                 ussd_clinic: [
                     'test/setup.js',
                     'src/session_length_helper.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_clinic %>',
                     'test/ussd_clinic.test.js'
                 ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_nurse: [
                     'src/index.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_nurse %>',
                     'src/init.js'
                 ],
@@ -170,6 +171,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_nurse: [
                     'test/setup.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_nurse %>',
                     'test/ussd_nurse.test.js'
                 ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,7 @@ module.exports = function (grunt) {
                 ussd_public: [
                     'src/index.js',
                     'src/session_length_helper.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_public %>',
                     'src/init.js'
                 ],
@@ -146,6 +147,7 @@ module.exports = function (grunt) {
                 ussd_public: [
                     'test/setup.js',
                     'src/session_length_helper.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_public %>',
                     'test/ussd_public.test.js'
                 ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,6 +100,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_popi_user_data: [
                     'src/index.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_popi_user_data %>',
                     'src/init.js'
                 ],
@@ -208,6 +209,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_popi_user_data: [
                     'test/setup.js',
+                    'src/engage.js',
                     '<%= paths.src.app.ussd_popi_user_data %>',
                     'test/ussd_popi_user_data.test.js'
                 ],

--- a/go-app-ussd_chw.js
+++ b/go-app-ussd_chw.js
@@ -174,6 +174,7 @@ go.app = function() {
         var hub;
         var ms;
         var sbm;
+        var engage;
 
         self.init = function() {
             // initialising services
@@ -197,6 +198,11 @@ go.app = function() {
                 new JsonApi(self.im, {}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
+            );
+            engage = new go.Engage(
+                new JsonApi(self.im, {}),
+                self.im.config.services.engage.url,
+                self.im.config.services.engage.token
             );
 
             self.env = self.im.config.env;
@@ -412,33 +418,7 @@ go.app = function() {
         };
 
         self.is_whatsapp_user = function(msisdn, wait_for_response) {
-            var whatsapp_config = self.im.config.whatsapp || {};
-            var api_url = whatsapp_config.api_url;
-            var api_token = whatsapp_config.api_token;
-            var api_number = whatsapp_config.api_number;
-
-            var params = {
-                number: api_number,
-                msisdns: [msisdn],
-                wait: wait_for_response,
-            };
-
-            return new JsonApi(self.im, {
-                headers: {
-                    'Authorization': ['Token ' + api_token]
-                }})
-                .post(api_url, {
-                    data: params,
-                })
-                .then(function(response) {
-                    var existing_users = _.filter(response.data, function(obj) { return obj.status === "valid"; });
-                    var is_user = !_.isEmpty(existing_users);
-                    return self.im
-                        .log('WhatsApp recipient ' + is_user + ' for ' + JSON.stringify(params))
-                        .then(function() {
-                            return is_user;
-                        });
-                });
+            return engage.contact_check(msisdn, wait_for_response);
         };
 
         self.add = function(name, creator) {

--- a/go-app-ussd_chw.js
+++ b/go-app-ussd_chw.js
@@ -177,30 +177,31 @@ go.app = function() {
         var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-CHW'}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -160,7 +160,6 @@ go.Engage = function() {
         self.base_url = base_url;
         self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
         self.json_api.defaults.headers['Content-Type'] = ['application/json'];
-        self.json_api.defaults.headers['User-Agent'] = ['VumiSandbox'];
 
         self.contact_check = function(msisdn, block) {
             return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
@@ -209,30 +208,31 @@ go.app = function() {
         var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-Clinic'}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_nurse.js
+++ b/go-app-ussd_nurse.js
@@ -1,8 +1,38 @@
 var go = {};
 go;
 
-go.app = function() {
+go.Engage = function() {
+    var vumigo = require('vumigo_v02');
+    var events = vumigo.events;
+    var Eventable = events.Eventable;
     var _ = require('lodash');
+    var url = require('url');
+
+    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
+        self.json_api = json_api;
+        self.base_url = base_url;
+        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
+        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
+
+        self.contact_check = function(msisdn, block) {
+            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
+                data: {
+                    blocking: block ? 'wait' : 'no_wait',
+                    contacts: [msisdn]
+                }
+            }).then(function(response) {
+                var existing = _.filter(response.data.contacts, function(obj) {
+                    return obj.status === "valid";
+                });
+                return !_.isEmpty(existing);
+            });
+        };
+    });
+
+    return Engage;
+}();
+
+go.app = function() {
     var vumigo = require("vumigo_v02");
     var moment = require('moment');
     var SeedJsboxUtils = require('seed-jsbox-utils');
@@ -27,29 +57,36 @@ go.app = function() {
         var sbm;
         var hub;
         var ms;
+        var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-Nurse'}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
+            );
+            engage = new go.Engage(
+                new JsonApi(self.im, config),
+                self.im.config.services.engage.url,
+                self.im.config.services.engage.token
             );
 
             self.env = self.im.config.env;
@@ -170,34 +207,7 @@ go.app = function() {
         };
 
         self.is_whatsapp_user = function(msisdn, wait_for_response) {
-            var whatsapp_config = self.im.config.whatsapp || {};
-            var api_url = whatsapp_config.api_url;
-            var api_token = whatsapp_config.api_token;
-            var api_number = whatsapp_config.api_number;
-
-            var params = {
-                number: api_number,
-                msisdns: [msisdn],
-                wait: wait_for_response,
-            };
-
-            return new JsonApi(self.im, {
-                headers: {
-                    'User-Agent': 'NDoH-JSBox/Nurse',
-                    'Authorization': ['Token ' + api_token]
-                }})
-                .post(api_url, {
-                    data: params,
-                })
-                .then(function(response) {
-                    var existing_users = _.filter(response.data, function(obj) { return obj.status === "valid"; });
-                    var is_user = !_.isEmpty(existing_users);
-                    return self.im
-                        .log('WhatsApp recipient ' + is_user + ' for ' + JSON.stringify(params))
-                        .then(function() {
-                            return is_user;
-                        });
-                });
+            return engage.contact_check(msisdn, wait_for_response);
         };
 
         self.number_opted_out = function(identity, msisdn) {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -148,6 +148,37 @@ go.SessionLengthHelper = function () {
 
 }();
 
+go.Engage = function() {
+    var vumigo = require('vumigo_v02');
+    var events = vumigo.events;
+    var Eventable = events.Eventable;
+    var _ = require('lodash');
+    var url = require('url');
+
+    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
+        self.json_api = json_api;
+        self.base_url = base_url;
+        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
+        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
+
+        self.contact_check = function(msisdn, block) {
+            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
+                data: {
+                    blocking: block ? 'wait' : 'no_wait',
+                    contacts: [msisdn]
+                }
+            }).then(function(response) {
+                var existing = _.filter(response.data.contacts, function(obj) {
+                    return obj.status === "valid";
+                });
+                return !_.isEmpty(existing);
+            });
+        };
+    });
+
+    return Engage;
+}();
+
 go.app = function() {
     var vumigo = require("vumigo_v02");
     var SeedJsboxUtils = require('seed-jsbox-utils');
@@ -171,29 +202,36 @@ go.app = function() {
         var sbm;
         var hub;
         var ms;
+        var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-Public'}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
+            );
+            engage = new go.Engage(
+                new JsonApi(self.im, config),
+                self.im.config.services.engage.url,
+                self.im.config.services.engage.token
             );
 
             self.env = self.im.config.env;
@@ -247,12 +285,12 @@ go.app = function() {
         };
 
         self.get_channel = function() {
-            var pilot_config = self.im.config.pilot || {};
+            var engage_config = self.im.config.services.engage;
             return Q()
                 .then(function() {
                     return self.im.log([
                         'pilot_state: ' + self.im.user.answers.state_pilot,
-                        'pilot config: ' + JSON.stringify(pilot_config),
+                        'engage config: ' + JSON.stringify(engage_config),
                     ].join('\n'));
                 })
                 .then(function () {
@@ -263,7 +301,7 @@ go.app = function() {
                     //      can be a race condition if we check the subscriptions too soon after
                     //      creating a new registration
                     if(self.im.user.answers.registered_on_whatsapp === true) {
-                        return pilot_config.channel;
+                        return engage_config.channel;
                     } else if(self.im.user.answers.registered_on_whatsapp === false) {
                         return self.im.config.services.message_sender.channel;
                     }
@@ -272,7 +310,7 @@ go.app = function() {
                         .is_identity_subscribed(self.im.user.answers.registrant.id, [/whatsapp/])
                         .then(function(confirmed) {
                             if(confirmed) {
-                                return pilot_config.channel;
+                                return engage_config.channel;
                             } else {
                                 return self.im.config.services.message_sender.channel;
                             }
@@ -527,12 +565,9 @@ go.app = function() {
                 // this is a quick call but WhatsApp in the background continues querying
                 // this contact, this means when we call it again the result will likely
                 // be available immediately when we call with with `wait` = `true`.
-                return self
-                    .can_participate_in_pilot({
-                        address: registrant_msisdn,
-                        wait: false,
-                    })
-                    .then(function(ignored_result) {
+                return engage
+                    .contact_check(registrant_msisdn, false)
+                    .then(function(_) {
                         return identity;
                     });
             })
@@ -725,64 +760,13 @@ go.app = function() {
 
         self.add('state_pilot_randomisation', function(name) {  // interstitial state
             var msisdn = utils.normalize_msisdn(self.im.user.addr, '27');
-            return self
-                .can_participate_in_pilot({
-                    address: msisdn,
-                    wait: true,
-                })
+            return engage
+                .contact_check(msisdn, true)
                 .then(function(yes_or_no) {
                     self.im.user.set_answer('registered_on_whatsapp', yes_or_no);
                     return self.states.create('state_save_subscription');
                 });
         });
-
-        self.can_participate_in_pilot = function (params) {
-            params = params || {};
-
-            if(_.isEmpty(self.im.config.pilot)) {
-                // If unconfigured return false
-                return Q(false);
-            }
-
-            var pilot_config = self.im.config.pilot || {};
-            var api_url = pilot_config.api_url;
-            var api_token = pilot_config.api_token;
-            var api_number = pilot_config.api_number;
-
-            var msisdn = params.address;
-
-            // Otherwise check the API
-            return new JsonApi(self.im, {
-                headers: {
-                    'User-Agent': 'NDoH-JSBox/Public',
-                    'Authorization': ['Token ' + api_token]
-                }})
-                .post(api_url, {
-                    data: {
-                        number: api_number,
-                        msisdns: [msisdn],
-                        wait: params.wait,
-                    },
-                })
-                .then(function(response) {
-                    var existing = _.filter(response.data, function(obj) { return obj.status === "valid"; });
-                    if(_.isEmpty(existing)) {
-                        // If they're not eligible then return false
-                        return self.im
-                            .log(msisdn + ' is not whatsappable')
-                            .then(function() {
-                                return false;
-                            });
-                    } else {
-                        // Otherwise return true
-                        return self.im
-                            .log(msisdn + ' is whatsappable')
-                            .then(function() {
-                                return true;
-                            });
-                    }
-                });
-        };
 
         self.add('state_save_subscription', function(name) {  // interstitial state
             var registration_info = self.compile_registration_info();

--- a/src/engage.js
+++ b/src/engage.js
@@ -10,7 +10,6 @@ go.Engage = function() {
         self.base_url = base_url;
         self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
         self.json_api.defaults.headers['Content-Type'] = ['application/json'];
-        self.json_api.defaults.headers['User-Agent'] = ['VumiSandbox'];
 
         self.contact_check = function(msisdn, block) {
             return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {

--- a/src/engage.js
+++ b/src/engage.js
@@ -1,0 +1,31 @@
+go.Engage = function() {
+    var vumigo = require('vumigo_v02');
+    var events = vumigo.events;
+    var Eventable = events.Eventable;
+    var _ = require('lodash');
+    var url = require('url');
+
+    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
+        self.json_api = json_api;
+        self.base_url = base_url;
+        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
+        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
+        self.json_api.defaults.headers['User-Agent'] = ['VumiSandbox'];
+
+        self.contact_check = function(msisdn, block) {
+            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
+                data: {
+                    blocking: block ? 'wait' : 'no_wait',
+                    contacts: [msisdn]
+                }
+            }).then(function(response) {
+                var existing = _.filter(response.data.contacts, function(obj) {
+                    return obj.status === "valid";
+                });
+                return !_.isEmpty(existing);
+            });
+        };
+    });
+
+    return Engage;
+}();

--- a/src/ussd_chw.js
+++ b/src/ussd_chw.js
@@ -27,30 +27,31 @@ go.app = function() {
         var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-CHW'}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_chw.js
+++ b/src/ussd_chw.js
@@ -24,6 +24,7 @@ go.app = function() {
         var hub;
         var ms;
         var sbm;
+        var engage;
 
         self.init = function() {
             // initialising services
@@ -47,6 +48,11 @@ go.app = function() {
                 new JsonApi(self.im, {}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
+            );
+            engage = new go.Engage(
+                new JsonApi(self.im, {}),
+                self.im.config.services.engage.url,
+                self.im.config.services.engage.token
             );
 
             self.env = self.im.config.env;
@@ -262,33 +268,7 @@ go.app = function() {
         };
 
         self.is_whatsapp_user = function(msisdn, wait_for_response) {
-            var whatsapp_config = self.im.config.whatsapp || {};
-            var api_url = whatsapp_config.api_url;
-            var api_token = whatsapp_config.api_token;
-            var api_number = whatsapp_config.api_number;
-
-            var params = {
-                number: api_number,
-                msisdns: [msisdn],
-                wait: wait_for_response,
-            };
-
-            return new JsonApi(self.im, {
-                headers: {
-                    'Authorization': ['Token ' + api_token]
-                }})
-                .post(api_url, {
-                    data: params,
-                })
-                .then(function(response) {
-                    var existing_users = _.filter(response.data, function(obj) { return obj.status === "valid"; });
-                    var is_user = !_.isEmpty(existing_users);
-                    return self.im
-                        .log('WhatsApp recipient ' + is_user + ' for ' + JSON.stringify(params))
-                        .then(function() {
-                            return is_user;
-                        });
-                });
+            return engage.contact_check(msisdn, wait_for_response);
         };
 
         self.add = function(name, creator) {

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -24,6 +24,7 @@ go.app = function() {
         var hub;
         var ms;
         var sbm;
+        var engage;
 
         self.init = function() {
             // initialise services
@@ -47,6 +48,11 @@ go.app = function() {
                 new JsonApi(self.im, {}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
+            );
+            engage = new go.Engage(
+                new JsonApi(self.im, {}),
+                self.im.config.services.engage.url,
+                self.im.config.services.engage.token
             );
 
             self.env = self.im.config.env;
@@ -514,36 +520,6 @@ go.app = function() {
             });
         });
 
-        self.is_valid_recipient_for_pilot = function (default_params) {
-            var pilot_config = self.im.config.pilot || {};
-            var api_url = pilot_config.api_url;
-            var api_token = pilot_config.api_token;
-            var api_number = pilot_config.api_number;
-
-            var params = _.merge({
-                number: api_number,
-            }, default_params);
-
-            // Otherwise check the API
-            return new JsonApi(self.im, {
-                headers: {
-                    'User-Agent': 'NDoH-JSBox/Clinic',
-                    'Authorization': ['Token ' + api_token]
-                }})
-                .post(api_url, {
-                    data: params,
-                })
-                .then(function(response) {
-                    var existing = _.filter(response.data, function(obj) { return obj.status === "valid"; });
-                    var allowed = !_.isEmpty(existing);
-                    return self.im
-                        .log('valid pilot recipient returning ' + allowed + ' for ' + JSON.stringify(params))
-                        .then(function () {
-                            return allowed;
-                        });
-                });
-        };
-
         self.add('state_clinic_code', function(name) {
             var error = $('Sorry, the clinic number did not validate. ' +
                           'Please reenter the clinic number.');
@@ -559,7 +535,7 @@ go.app = function() {
                             return error;
                         } else {
                             var address = self.im.user.answers.registrant_msisdn;
-                            return self
+                            return engage
                                 // NOTE:    We're making the API call here but not telling
                                 //          it to wait nor are we doing anything with the
                                 //          result.
@@ -568,10 +544,7 @@ go.app = function() {
                                 //          to happen in the background and will be ready
                                 //          when we need it. This way we minimise any timeout
                                 //          penalty during the registration.
-                                .is_valid_recipient_for_pilot({
-                                    msisdns: [address],
-                                    wait: false
-                                })
+                                .contact_check(address, false)
                                 .then(function () {
                                     return null;  // vumi expects null or undefined if check passes
                                 });
@@ -826,11 +799,8 @@ go.app = function() {
 
         self.add('state_channel_select', function(name) {  // interstitial state
             var address = self.im.user.answers.registrant_msisdn;
-            return self
-                .is_valid_recipient_for_pilot({
-                    msisdns: [address],
-                    wait: true
-                })
+            return engage
+                .contact_check(address, true)
                 .then(function(confirmed) {
                     self.im.user.set_answer('registered_on_whatsapp', confirmed);
                     return self.states.create('state_save_subscription');

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -27,30 +27,31 @@ go.app = function() {
         var engage;
 
         self.init = function() {
+            var config = {headers: {'User-Agent': 'Jsbox/NDoH-Clinic'}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, {}),
+                new JsonApi(self.im, config),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/test/fixtures_pilot.js
+++ b/test/fixtures_pilot.js
@@ -7,24 +7,24 @@ module.exports = function() {
             'request': {
                 'method': 'POST',
                 'headers': {
-                    'Authorization': ['Token api-token'],
-                    'Content-Type': ['application/json']
+                    'Authorization': ['Bearer api-token'],
+                    'Content-Type': ['application/json'],
+                    'User-Agent': ['VumiSandbox']
                 },
-                'url': 'http://pilot.example.org/api/v1/lookups/',
-                'body': JSON.stringify({
-                    'number': params.number,
-                    'msisdns': [params.address],
-                    'wait': params.wait,
-                }),
+                'url': 'http://pilot.example.org/v1/contacts',
+                'data': {
+                    'blocking': params.wait ? 'wait' : 'no_wait',
+                    'contacts': [params.address],
+                },
             },
             'response': {
                 'code': 200,
-                'data': [{
-                    "msisdn": params.address,
-                    "wa_exists": exists,
-                    "status": exists ? "valid" : "invalid",
-                    "wa_username": params.address,
-                }]
+                'data': {
+                    'contacts': [{
+                        'input': params.address,
+                        'status': exists ? 'valid' : 'invalid'
+                    }]
+                }
             }
         };
     }

--- a/test/fixtures_pilot.js
+++ b/test/fixtures_pilot.js
@@ -8,8 +8,7 @@ module.exports = function() {
                 'method': 'POST',
                 'headers': {
                     'Authorization': ['Bearer api-token'],
-                    'Content-Type': ['application/json'],
-                    'User-Agent': ['VumiSandbox']
+                    'Content-Type': ['application/json']
                 },
                 'url': 'http://pilot.example.org/v1/contacts',
                 'data': {

--- a/test/ussd_chw.test.js
+++ b/test/ussd_chw.test.js
@@ -53,13 +53,12 @@ describe("app", function() {
                         stage_based_messaging: {
                             url: 'http://sbm/api/v1/',
                             token: 'test StageBasedMessaging'
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'api-token'
                         }
-                    },
-                    whatsapp: {
-                        api_url: 'http://pilot.example.org/api/v1/lookups/',
-                        api_token: 'api-token',
-                        api_number: '+27000000000',
-                    },
+                    }
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -58,13 +58,11 @@ describe("app", function() {
                         stage_based_messaging: {
                             url: 'http://sbm/api/v1/',
                             token: 'test StageBasedMessaging'
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'api-token'
                         }
-                    },
-                    pilot: {
-                        api_url: 'http://pilot.example.org/api/v1/lookups/',
-                        api_token: 'api-token',
-                        api_number: '+27123456789',
-                        channel: 'pilot-channel',
                     }
                 })
                 .setup(function(api) {

--- a/test/ussd_nurse.test.js
+++ b/test/ussd_nurse.test.js
@@ -52,6 +52,10 @@ describe("app", function() {
                         message_sender: {
                             url: 'http://ms/api/v1/',
                             token: 'test MessageSender'
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'api-token',
                         }
                     },
                     no_timeout_redirects: [
@@ -60,12 +64,7 @@ describe("app", function() {
                         'state_end_detail_changed',
                         'state_end_reg',
                         'state_block_active_subs'
-                    ],
-                    whatsapp: {
-                        api_url: 'http://pilot.example.org/api/v1/lookups/',
-                        api_token: 'api-token',
-                        api_number: '+27000000000',
-                    },
+                    ]
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};

--- a/test/ussd_popi_user_data.test.js
+++ b/test/ussd_popi_user_data.test.js
@@ -44,12 +44,11 @@ describe('app', function() {
                         hub: {
                             url: 'http://hub/api/v1/',
                             token: 'test Hub'
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'api-token',
                         }
-                    },
-                    pilot: {
-                        api_url: 'http://pilot.example.org/api/v1/lookups/',
-                        api_token: 'api-token',
-                        api_number: '+27123456789',
                     }
                 })
                 .setup(function(api) {

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -56,6 +56,11 @@ describe("ussd_public app", function() {
                         message_sender: {
                             url: 'http://ms/api/v1/',
                             token: 'test MessageSender'
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'test-token',
+                            channel: 'pilot-channel'
                         }
                     },
                 })
@@ -70,6 +75,22 @@ describe("ussd_public app", function() {
                     fixtures_ServiceRating().forEach(api.http.fixtures.add); // 150 - 169
                     fixtures_Jembi().forEach(api.http.fixtures.add);  // 170 - 179
                     fixtures_IdentityStore().forEach(api.http.fixtures.add); // 180 ->
+                    var numbers = [
+                        '+27820001001', '+27820001002', '+27820001004', '+27820001006', '+27820001007',
+                        '+27820001008', '+27820001011'
+                    ];
+                    for(var i in numbers) {
+                        api.http.fixtures.add(
+                            fixtures_Pilot().not_exists({
+                                address: numbers[i],
+                                wait: false,
+                        }));
+                        api.http.fixtures.add(
+                            fixtures_Pilot().not_exists({
+                                address: numbers[i],
+                                wait: true,
+                        }));
+                    }
                 });
         });
 
@@ -146,7 +167,7 @@ describe("ussd_public app", function() {
                         assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [2]);
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
+                        utils.check_fixtures_used(api, [17, 180, 183, 198, 252, 253, 266]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -245,7 +266,7 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [50, 125, 180, 183]);
+                    utils.check_fixtures_used(api, [50, 125, 180, 183, 252]);
                 })
                 .run();
             });
@@ -259,7 +280,7 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [53, 54, 127, 207]);
+                    utils.check_fixtures_used(api, [53, 54, 127, 207, 264]);
                 })
                 .run();
             });
@@ -272,7 +293,7 @@ describe("ussd_public app", function() {
                     , {session_event: 'close'}
                 )
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [54, 59, 129, 202]);
+                    utils.check_fixtures_used(api, [54, 59, 129, 202, 262]);
                 })
                 .run();
             });
@@ -300,7 +321,7 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", false)  // session closed on non-dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
+                    utils.check_fixtures_used(api, [17, 180, 183, 198, 252, 253, 266]);
                 })
                 .run();
             });
@@ -328,7 +349,7 @@ describe("ussd_public app", function() {
                 )
                 .check.user.answer("redial_sms_sent", true)  // session closed on dialback state
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [17, 50, 125, 180, 183, 208, 252]);
+                    utils.check_fixtures_used(api, [17, 50, 125, 180, 183, 208, 252, 253, 266]);
                 })
                 .run();
             });
@@ -355,7 +376,7 @@ describe("ussd_public app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [180, 183]);
+                        utils.check_fixtures_used(api, [180, 183, 252]);
                     })
                     // check metrics
                     .check(function(api) {
@@ -392,7 +413,7 @@ describe("ussd_public app", function() {
                             ].join('\n')
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [51, 54, 181]);
+                            utils.check_fixtures_used(api, [51, 54, 181, 254]);
                         })
                         .run();
                     });
@@ -417,7 +438,7 @@ describe("ussd_public app", function() {
                             ].join('\n')
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [58, 196]);
+                            utils.check_fixtures_used(api, [58, 196, 258]);
                         })
                         .run();
                     });
@@ -440,7 +461,7 @@ describe("ussd_public app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [197]);
+                        utils.check_fixtures_used(api, [197, 260]);
                     })
                     .run();
                 });
@@ -567,7 +588,7 @@ describe("ussd_public app", function() {
                             assert.deepEqual(metrics['test.ussd_public.avg.sessions_to_register'].values, [1]);
                         })
                         .check(function(api) {
-                            utils.check_fixtures_used(api, [17, 180, 183, 198, 252]);
+                            utils.check_fixtures_used(api, [17, 180, 183, 198, 252, 253, 266]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -647,7 +668,7 @@ describe("ussd_public app", function() {
                         state: "state_end_success"
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [18, 184, 199, 238, 252]);
+                        utils.check_fixtures_used(api, [18, 184, 199, 238, 256, 257, 266]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -692,7 +713,7 @@ describe("ussd_public app", function() {
                             'your compliment.'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 119, 181]);
+                        utils.check_fixtures_used(api, [51, 54, 119, 181, 254]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -713,7 +734,7 @@ describe("ussd_public app", function() {
                             'your complaint.'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 120, 181]);
+                        utils.check_fixtures_used(api, [51, 54, 120, 181, 254]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -736,7 +757,7 @@ describe("ussd_public app", function() {
                             'messages, please visit your nearest clinic.'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [197]);
+                        utils.check_fixtures_used(api, [197, 260]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -786,15 +807,12 @@ describe("ussd_public app", function() {
                             url: 'http://ms/api/v1/',
                             token: 'test MessageSender',
                             channel: 'default-channel',
+                        },
+                        engage: {
+                            url: 'http://pilot.example.org',
+                            token: 'test-token',
+                            channel: 'pilot-channel'
                         }
-                    },
-                    pilot: {
-                        whitelist: [],
-                        randomisation_treshold: 0.5,
-                        api_url: 'http://pilot.example.org/api/v1/lookups/',
-                        api_token: 'api-token',
-                        api_number: '+27123456789',
-                        channel: 'pilot-channel',
                     }
                 })
                 .setup(function(api) {


### PR DESCRIPTION
Currently the contact checks are still on the old Wassup API, which is deprecated and scheduled to be turned off.

This PR moves the contact checks over to the new Engage API, and also extracts them into a separate module, removing a lot of duplicate code.