### PR TITLE
Fix default HTTP header specification

### DIFF
--- a/go-app-ussd_chw.js
+++ b/go-app-ussd_chw.js
@@ -208,31 +208,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-CHW']}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -208,31 +208,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Clinic']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_nurse.js
+++ b/go-app-ussd_nurse.js
@@ -60,31 +60,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Nurse']}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_popi_user_data.js
+++ b/go-app-ussd_popi_user_data.js
@@ -62,25 +62,24 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-POPIUserData']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -205,31 +205,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Public']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_chw.js
+++ b/src/ussd_chw.js
@@ -27,31 +27,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-CHW']}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-CHW"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -27,31 +27,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Clinic']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_nurse.js
+++ b/src/ussd_nurse.js
@@ -26,31 +26,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Nurse']}};
             // initialising services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Nurse"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_popi_user_data.js
+++ b/src/ussd_popi_user_data.js
@@ -28,25 +28,24 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-POPIUserData']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPIUserData"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -24,31 +24,30 @@ go.app = function() {
         var engage;
 
         self.init = function() {
-            var config = {headers: {'User-Agent': ['Jsbox/NDoH-Public']}};
             // initialise services
             is = new SeedJsboxUtils.IdentityStore(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.identity_store.token,
                 self.im.config.services.identity_store.url
             );
             sbm = new SeedJsboxUtils.StageBasedMessaging(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.stage_based_messaging.token,
                 self.im.config.services.stage_based_messaging.url
             );
             hub = new SeedJsboxUtils.Hub(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.hub.token,
                 self.im.config.services.hub.url
             );
             ms = new SeedJsboxUtils.MessageSender(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.message_sender.token,
                 self.im.config.services.message_sender.url,
                 self.im.config.services.message_sender.channel
             );
             engage = new go.Engage(
-                new JsonApi(self.im, config),
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Public"]}}),
                 self.im.config.services.engage.url,
                 self.im.config.services.engage.token
             );


### PR DESCRIPTION
When specifying default headers for the JsonApi, it doens't do a copy, it just uses the object that was passed in. This creates an issue with each new client created, where the authorization headers keep getting overwritten, because they're all sharing the same config object.

This PR fixes that by giving each client it's own configuration object.