### PR TITLE
Fix next state for state_not_registered

### DIFF
--- a/go-app-ussd_popi_faq.js
+++ b/go-app-ussd_popi_faq.js
@@ -226,7 +226,7 @@ go.app = function() {
                         'the number you first used to register. To update ' +
                         'your number, dial *134*550*7# or register again at ' +
                         'a clinic.'),
-                next: 'start_state'
+                next: 'state_start'
             });
         });
     });

--- a/src/ussd_popi_faq.js
+++ b/src/ussd_popi_faq.js
@@ -223,7 +223,7 @@ go.app = function() {
                         'the number you first used to register. To update ' +
                         'your number, dial *134*550*7# or register again at ' +
                         'a clinic.'),
-                next: 'start_state'
+                next: 'state_start'
             });
         });
     });


### PR DESCRIPTION
Currently, it's set to `start_state`, which is not a valid state, so it errors, and goes to the default `state_start` state. So while it has the intended effect, it creates noise in our error tracking