### PR TITLE
Feature/momza 1075 fix clinic ussd already registered number

### DIFF
--- a/go-app-ussd_clinic.js
+++ b/go-app-ussd_clinic.js
@@ -555,6 +555,7 @@ go.app = function() {
                             } else {
                                 self.im.user.set_answer("redial_sms_sent", false);
                             }
+                            
                             self.im.user.set_answer("registrant", self.im.user.answers.operator);
                             self.im.user.set_answer("registrant_msisdn", operator_msisdn);
 
@@ -577,8 +578,8 @@ go.app = function() {
 
         self.add('state_already_subscribed', function(name) {
             var country_code = '27',
-                operator_msisdn = utils.normalize_msisdn(self.im.user.addr, country_code),
-                readable_number = utils.readable_msisdn(operator_msisdn, country_code);
+                registrant_msisdn = self.im.user.answers.registrant_msisdn,
+                readable_number = utils.readable_msisdn(registrant_msisdn, country_code);
 
             return new MenuState(name, {
                 question: $(
@@ -673,7 +674,7 @@ go.app = function() {
                     .then(function(identity) {
                         self.im.user.set_answer("registrant", identity);
                         self.im.user.set_answer("registrant_msisdn", registrant_msisdn);
-
+                
                         return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
                     })
                     .then(function(has_active_subscription) {

--- a/src/ussd_clinic.js
+++ b/src/ussd_clinic.js
@@ -374,6 +374,7 @@ go.app = function() {
                             } else {
                                 self.im.user.set_answer("redial_sms_sent", false);
                             }
+                            
                             self.im.user.set_answer("registrant", self.im.user.answers.operator);
                             self.im.user.set_answer("registrant_msisdn", operator_msisdn);
 
@@ -396,8 +397,8 @@ go.app = function() {
 
         self.add('state_already_subscribed', function(name) {
             var country_code = '27',
-                operator_msisdn = utils.normalize_msisdn(self.im.user.addr, country_code),
-                readable_number = utils.readable_msisdn(operator_msisdn, country_code);
+                registrant_msisdn = self.im.user.answers.registrant_msisdn,
+                readable_number = utils.readable_msisdn(registrant_msisdn, country_code);
 
             return new MenuState(name, {
                 question: $(
@@ -492,7 +493,7 @@ go.app = function() {
                     .then(function(identity) {
                         self.im.user.set_answer("registrant", identity);
                         self.im.user.set_answer("registrant_msisdn", registrant_msisdn);
-
+                
                         return sbm.is_identity_subscribed(identity.id, [/prebirth\.hw_full/]);
                     })
                     .then(function(has_active_subscription) {

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -574,6 +574,33 @@ describe("app", function() {
             });
         });
 
+        describe("when on state_mobile_no and number has no subscription", function() {
+            it("should go to state_consent", function() {
+                return tester
+                .setup(function(api) {
+                    api.http.fixtures.add(fixtures_IdentityStoreDynamic.identity_search({
+                        'msisdn': '+27820001001'
+                    }));
+                    api.http.fixtures.add(fixtures_StageBasedMessagingDynamic.active_subscriptions());
+                })
+                .setup.user.answer('operator', {'id': 'operator-id'})
+                .setup.user.answer('operator_msisdn', '+27820001002')
+                .setup.user.state('state_mobile_no')
+                .input('0820001001')
+                .check.interaction({
+                    state: "state_consent",
+                    reply: [
+                            'We need to collect, store & use her info. She ' +
+                            'may get messages on public holidays & weekends. ' +
+                            'Does she consent?',
+                            '1. Yes',
+                            '2. No'
+                    ].join('\n')
+                })
+                .run();
+            });
+        });
+
         describe("timeout testing", function() {
             describe("when you timeout and dial back in", function() {
                 describe("when on a normal state", function() {
@@ -986,6 +1013,7 @@ describe("app", function() {
                 it('should return state_already_subscribed if active subscription', function() {
                     return tester
                     .setup.user.addr('27820001002')
+                    .setup.user.answer('registrant_msisdn', '27820001002')
                     .setup(function(api) {
                         api.http.fixtures.add(
                             fixtures_IdentityStoreDynamic.identity_search({
@@ -1017,6 +1045,7 @@ describe("app", function() {
             it('should offer the choice to enter a different number', function() {
                 return tester
                 .setup.user.addr('27820001002')
+                .setup.user.answer('registrant_msisdn', '27820001002')
                 .setup.user.state("state_already_subscribed")
                 .input("1")
                 .check.interaction({
@@ -1028,6 +1057,7 @@ describe("app", function() {
             it('should offer the choice to go back to the start', function() {
                 return tester
                 .setup.user.addr('27820001002')
+                .setup.user.answer('registrant_msisdn', '27820001002')
                 .setup.user.state("state_already_subscribed")
                 .setup(function(api) {
                     api.http.fixtures.add(

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -1013,7 +1013,6 @@ describe("app", function() {
                 it('should return state_already_subscribed if active subscription for number entered', function() {
                     return tester
                     .setup.user.addr('27820001002')
-                    //.setup.user.answer('registrant_msisdn', '27820001008')
                     .setup(function(api) {
                         api.http.fixtures.add(
                             fixtures_IdentityStoreDynamic.identity_search({

--- a/test/ussd_clinic.test.js
+++ b/test/ussd_clinic.test.js
@@ -1010,6 +1010,50 @@ describe("app", function() {
             });
 
             describe('checking for existing subscriptions', function() {
+                it('should return state_already_subscribed if active subscription for number entered', function() {
+                    return tester
+                    .setup.user.addr('27820001002')
+                    //.setup.user.answer('registrant_msisdn', '27820001008')
+                    .setup(function(api) {
+                        api.http.fixtures.add(
+                            fixtures_IdentityStoreDynamic.identity_search({
+                                msisdn: "+27820001002",
+                                opted_out: true
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_IdentityStoreDynamic.identity_search({
+                                msisdn: "+27820001008",
+                                opted_out: true
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_StageBasedMessagingDynamic.messagesets({
+                                short_names: ['momconnect_prebirth.hw_full.1']
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_StageBasedMessagingDynamic.active_subscriptions({
+                                messagesets: [0]
+                            })
+                        );
+                    })
+                    .setup.user.state('state_mobile_no')
+                    .input('0820001008')
+                    .check.interaction({
+                        state: 'state_already_subscribed',
+                        reply: [
+                            'The number 0820001008 already has an active subscription to MomConnect. ' +
+                            'Would you like to use a different number?',
+                            '1. Use a different number',
+                            '2. End registration'
+                        ].join('\n')
+                    })
+                    .run();
+                });
+            });
+            
+            describe('checking for existing subscriptions', function() {
                 it('should return state_already_subscribed if active subscription', function() {
                     return tester
                     .setup.user.addr('27820001002')


### PR DESCRIPTION
Fix for clinic USSD line, if the number entered already has an active momconnect subscription, then it shows an error message. But that error message shows the number that is dialling the line, not the number that was checked for an active subscription

Initially, it was using the operator msisdn to check the subscription, and not the registrant msisdn (which in most cases is different from the operator msisdn)