### PR TITLE
Feature/momza 1075 fix chw ussd already registered number

### DIFF
--- a/go-app-ussd_chw.js
+++ b/go-app-ussd_chw.js
@@ -539,8 +539,8 @@ go.app = function() {
 
         self.add('state_already_subscribed', function(name) {
             var country_code = '27',
-                operator_msisdn = utils.normalize_msisdn(self.im.user.addr, country_code),
-                readable_number = utils.readable_msisdn(operator_msisdn, country_code);
+                registrant_msisdn = self.im.user.answers.registrant_msisdn,
+                readable_number = utils.readable_msisdn(registrant_msisdn, country_code);
 
             return new MenuState(name, {
                 question: $(

--- a/src/ussd_chw.js
+++ b/src/ussd_chw.js
@@ -358,8 +358,8 @@ go.app = function() {
 
         self.add('state_already_subscribed', function(name) {
             var country_code = '27',
-                operator_msisdn = utils.normalize_msisdn(self.im.user.addr, country_code),
-                readable_number = utils.readable_msisdn(operator_msisdn, country_code);
+                registrant_msisdn = self.im.user.answers.registrant_msisdn,
+                readable_number = utils.readable_msisdn(registrant_msisdn, country_code);
 
             return new MenuState(name, {
                 question: $(


### PR DESCRIPTION
Fix for CHW USSD line, if the number entered already has an active momconnect subscription, then it shows an error message. But that error message shows the number that is dialling the line, not the number that was checked for an active subscription

Initially, it was using the operator msisdn to check the subscription, and not the registrant msisdn (which in most cases is different from the operator msisdn)