### PR TITLE
PMTCT pre to post missing baby dob fix

### DIFF
--- a/go-app-ussd_pmtct_seed.js
+++ b/go-app-ussd_pmtct_seed.js
@@ -431,6 +431,9 @@ go.app = function() {
             .then(function() {
                 var reg_info;
                 var subscription_type = self.im.user.answers.subscription_type;
+
+                var last_edd = self.im.user.answers.identity.details.last_edd;
+                var last_baby_dob = self.im.user.answers.identity.details.last_baby_dob;
                 if (subscription_type === "postbirth") {
                     reg_info = {
                         "reg_type": "pmtct_postbirth",
@@ -439,7 +442,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "baby_dob": self.im.user.answers.identity.details.last_baby_dob,
+                            "baby_dob": last_baby_dob || last_edd,
                         }
                     };
 
@@ -451,7 +454,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "edd": self.im.user.answers.identity.details.last_edd
+                            "edd": last_edd
                         }
                     };
                 }

--- a/src/ussd_pmtct_seed.js
+++ b/src/ussd_pmtct_seed.js
@@ -428,6 +428,9 @@ go.app = function() {
             .then(function() {
                 var reg_info;
                 var subscription_type = self.im.user.answers.subscription_type;
+
+                var last_edd = self.im.user.answers.identity.details.last_edd;
+                var last_baby_dob = self.im.user.answers.identity.details.last_baby_dob;
                 if (subscription_type === "postbirth") {
                     reg_info = {
                         "reg_type": "pmtct_postbirth",
@@ -436,7 +439,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "baby_dob": self.im.user.answers.identity.details.last_baby_dob,
+                            "baby_dob": last_baby_dob || last_edd,
                         }
                     };
 
@@ -448,7 +451,7 @@ go.app = function() {
                             "operator_id": self.im.user.answers.identity.id,
                             "language": self.im.user.lang || "eng_ZA",
                             "mom_dob": self.im.user.answers.mom_dob,
-                            "edd": self.im.user.answers.identity.details.last_edd
+                            "edd": last_edd
                         }
                     };
                 }

--- a/test/fixtures_identity_store_dynamic.js
+++ b/test/fixtures_identity_store_dynamic.js
@@ -39,7 +39,8 @@ module.exports = function() {
                                     "sa_id_no": "5101025009086",
                                     "mom_dob": "1951-01-02",
                                     "source": "clinic",
-                                    "last_mc_reg_on": "clinic"
+                                    "last_mc_reg_on": "clinic",
+                                    "last_edd": params.last_edd || null,
                                 },
                                 "created_at": "2016-08-05T06:13:29.693272Z",
                                 "updated_at": "2016-08-05T06:13:29.693298Z"

--- a/test/ussd_pmtct_seed.test.js
+++ b/test/ussd_pmtct_seed.test.js
@@ -9,6 +9,10 @@ var fixtures_Hub = require('./fixtures_hub');
 var fixtures_Jembi = require('./fixtures_jembi');
 var fixtures_Pilot = require('./fixtures_pilot');
 var fixtures_ServiceRating = require('./fixtures_service_rating');
+var fixtures_IdentityStoreDynamic = require('./fixtures_identity_store_dynamic')();
+var fixtures_StageBasedMessagingDynamic = require('./fixtures_stage_based_messaging_dynamic')();
+var fixtures_HubDynamic = require('./fixtures_hub_dynamic')();
+var fixtures_MessageSenderDynamic = require('./fixtures_message_sender_dynamic')();
 
 var utils = require('seed-jsbox-utils').utils;
 
@@ -538,6 +542,88 @@ describe("PMTCT app", function() {
                         })
                         .check.reply.ends_session()
                         .run();
+                });
+            });
+
+            describe("0820001111 has active non-pmtct subscription; consent, no dob, edd", function() {
+                it("to state_end_hiv_messages_confirm (entire flow)", function() {
+                    return tester
+                    .setup.user.addr("0820001111")
+                    .setup(function(api) {
+                        api.http.fixtures.fixtures = [];
+                        api.http.fixtures.add(
+                            fixtures_IdentityStoreDynamic.identity_search({
+                                msisdn: "+27820001111",
+                                last_edd: "2016-06-03"
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_IdentityStoreDynamic.update({
+                                details: {
+                                    "default_addr_type":"msisdn",
+                                    "addresses":{
+                                        "msisdn":{
+                                            "+27820001111":{
+                                                "default":true,
+                                                "optedout":false
+                                            }
+                                        }
+                                    },
+                                    "lang_code":"eng_ZA",
+                                    "consent":true,
+                                    "sa_id_no":"5101025009086",
+                                    "mom_dob":"1951-01-02",
+                                    "source":"clinic",
+                                    "last_mc_reg_on":"clinic",
+                                    "last_edd":"2016-06-03",
+                                    "pmtct":{"lang_code":"eng_ZA"}},
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_StageBasedMessagingDynamic.messagesets({
+                                short_names: ['momconnect_postbirth.hw_full.1']
+                            })
+                        );
+                        api.http.fixtures.add(
+                            fixtures_StageBasedMessagingDynamic.active_subscriptions({
+                                messagesets: [0]
+                            })
+                        );
+                        api.http.fixtures.add(fixtures_HubDynamic.registration({
+                            reg_type: "pmtct_postbirth",
+                            data: {
+                                "operator_id":"cb245673-aa41-4302-ac47-00000001002",
+                                "language":"eng_ZA",
+                                "mom_dob":"1951-01-02",
+                                "baby_dob":"2016-06-03"
+                            }
+                        }));
+                        api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                            to_identity: "cb245673-aa41-4302-ac47-00000001002",
+                            to_addr: "+27820001111",
+                            content: "HIV positive moms can have an HIV negative baby! You can get free medicine at the clinic to protect your baby and improve your health",
+                            channel: "default-channel",
+                        }));
+                        api.http.fixtures.add(fixtures_MessageSenderDynamic.send_message({
+                            to_identity: "cb245673-aa41-4302-ac47-00000001002",
+                            to_addr: "+27820001111",
+                            content: "Recently tested HIV positive? You are not alone, many other pregnant women go through this. Visit b-wise.mobi or call the AIDS Helpline 0800 012 322",
+                            channel: "default-channel",
+                        }));
+                    })
+                    .inputs(
+                        {session_event: "new"}  // dial in
+                        , "1"  // state_hiv_messages - yes
+                    )
+                    .check.interaction({
+                        state: "state_end_hiv_messages_confirm",
+                        reply: "You will now start receiving messages about keeping your child HIV-negative. Thank you for using the MomConnect service. Goodbye."
+                    })
+                    .check(function(api) {
+                        utils.check_fixtures_used(api, [0, 1, 2, 3, 4, 5, 6]);
+                    })
+                    .check.reply.ends_session()
+                    .run();
                 });
             });
 


### PR DESCRIPTION
If a mom registers for prebirth and moves to postbirth, then tries to register for PMTCT it fails with missing baby date of birth.

In this case we should use the last edd we had.