### PR TITLE
Fix tsonga translations for popi user data

### DIFF
--- a/config/go-app-ussd_popi_user_data.tso_ZA.json
+++ b/config/go-app-ussd_popi_user_data.tso_ZA.json
@@ -2,7 +2,7 @@
     "": {
         "project-id-version": "POPI_USER_DATA",
         "pot-creation-date": "2018-10-03 10:07:+0000",
-        "po-revision-date": "2018-10-25 14:50+0200",
+        "po-revision-date": "2019-01-10 09:01+0200",
         "last-translator": "Kaitlyn Crawford <kaitlyn@praekelt.org>",
         "language-team": "Tsonga <LL@li.org>",
         "language": "ts",
@@ -73,7 +73,7 @@
     ],
     "Receive messages over {{channel}}": [
         null,
-        "Kuma swihungwana hi {{chanele}}"
+        "Kuma swihungwana hi {{channel}}"
     ],
     "What would you like to change? To change your due date, visit a clinic": [
         null,
@@ -93,7 +93,7 @@
     ],
     "Thank you. Your info has been updated. You will now receive messages from MomConnect via {{channel}}.": [
         null,
-        "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect hi {{chanele}}"
+        "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect hi {{channel}}"
     ],
     "Update my other info": [
         null,
@@ -149,7 +149,7 @@
     ],
     "Thank you. Your info has been updated. You will now receive messages from MomConnect in {{language}}.": [
         null,
-        "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect hi {{ririmi}}"
+        "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect hi {{language}}"
     ],
     "What kind of identification do you have?": [
         null,
@@ -213,7 +213,7 @@
     ],
     "Thank you. Your info has been updated. Your registered identification is {{identification_type}} {{identification_number}}.": [
         null,
-        "Ha khensa. Vuxokoxoko byi pfuxetiwile. Vutitivisi bya wena lebyi tsariweke i {{muxaka_wa_vutitivisi}}                      {{nomboro _ya_pasi}}"
+        "Ha khensa. Vuxokoxoko byi pfuxetiwile. Vutitivisi bya wena lebyi tsariweke i {{identification_type}} {{identification_number}}"
     ],
     "Please enter the new phone number we should use to send you messages eg. 0813547654": [
         null,
@@ -297,11 +297,11 @@
     ],
     "Sorry the number you have entered is not valid. Please re-enter the mobile number.": [
         null,
-        "Hi khomele, nomboro leyi u yi ngheniseke a yi  amukeleki. Nghenisa nomboro ya selifoni nakambe."
+        "Hi khomele, nomboro leyi u yi ngheniseke a yi amukeleki. Nghenisa nomboro ya selifoni nakambe."
     ],
     "You have entered {{new_number}} as the new number you would like to receive MomConnect messages on. Is this number correct?": [
         null,
-        "U nghenisile {{nomboro_leyintshwa}} tanihi nomboro leyi u lavaka ku kuma swihungwana swa MomConnect eka yona. Xana nomboro leyi yi lulamile?"
+        "U nghenisile {{new_number}} tanihi nomboro leyi u lavaka ku kuma swihungwana swa MomConnect eka yona. Xana nomboro leyi yi lulamile?"
     ],
     "No - enter again": [
         null,
@@ -317,6 +317,6 @@
     ],
     "Your number has been changed successfully to {{msisdn}}. You will receive messages on {{channel}}. Thank you for using MomConnect!": [
         null,
-        "Nomboro ya wena yi cinciwile kahle eka {{msisdn}}. U ta kuma swihungwana hi {{chanele}}. Ha khensa ku va u tirhisa MomConnect!"
+        "Nomboro ya wena yi cinciwile kahle eka {{msisdn}}. U ta kuma swihungwana hi {{channel}}. Ha khensa ku va u tirhisa MomConnect!"
     ]
 }

--- a/config/go-app-ussd_popi_user_data.tso_ZA.po
+++ b/config/go-app-ussd_popi_user_data.tso_ZA.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: POPI_USER_DATA\n"
 "POT-Creation-Date: 2018-10-03 10:07:+0000\n"
-"PO-Revision-Date: 2018-10-25 14:50+0200\n"
+"PO-Revision-Date: 2019-01-10 09:01+0200\n"
 "Last-Translator: Kaitlyn Crawford <kaitlyn@praekelt.org>\n"
 "Language-Team: Tsonga <LL@li.org>\n"
 "Language: ts\n"
@@ -105,7 +105,7 @@ msgstr "Ku cinca vutitivisi bya mina"
 
 #: go-app-ussd_popi_user_data.js:327
 msgid "Receive messages over {{channel}}"
-msgstr "Kuma swihungwana hi {{chanele}}"
+msgstr "Kuma swihungwana hi {{channel}}"
 
 #: go-app-ussd_popi_user_data.js:334
 msgid "What would you like to change? To change your due date, visit a clinic"
@@ -133,7 +133,7 @@ msgid ""
 "MomConnect via {{channel}}."
 msgstr ""
 "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect "
-"hi {{chanele}}"
+"hi {{channel}}"
 
 #: go-app-ussd_popi_user_data.js:389 go-app-ussd_popi_user_data.js:446
 #: go-app-ussd_popi_user_data.js:556 go-app-ussd_popi_user_data.js:667
@@ -194,7 +194,7 @@ msgid ""
 "MomConnect in {{language}}."
 msgstr ""
 "Ha khensa. Vuxokoxoko byi pfuxetiwile. U ta kuma swihungwana swa MomConnect "
-"hi {{ririmi}}"
+"hi {{language}}"
 
 #: go-app-ussd_popi_user_data.js:453
 msgid "What kind of identification do you have?"
@@ -267,7 +267,7 @@ msgid ""
 "{{identification_type}} {{identification_number}}."
 msgstr ""
 "Ha khensa. Vuxokoxoko byi pfuxetiwile. Vutitivisi bya wena lebyi tsariweke i "
-"{{muxaka_wa_vutitivisi}}                      {{nomboro _ya_pasi}}"
+"{{identification_type}} {{identification_number}}"
 
 #: go-app-ussd_popi_user_data.js:563
 msgid ""
@@ -417,16 +417,16 @@ msgid ""
 "Sorry the number you have entered is not valid. Please re-enter the mobile "
 "number."
 msgstr ""
-"Hi khomele, nomboro leyi u yi ngheniseke a yi  amukeleki. Nghenisa nomboro "
-"ya selifoni nakambe."
+"Hi khomele, nomboro leyi u yi ngheniseke a yi amukeleki. Nghenisa nomboro ya "
+"selifoni nakambe."
 
 #: go-app-ussd_popi_user_data.js:911
 msgid ""
 "You have entered {{new_number}} as the new number you would like to receive "
 "MomConnect messages on. Is this number correct?"
 msgstr ""
-"U nghenisile {{nomboro_leyintshwa}} tanihi nomboro leyi u lavaka ku kuma "
-"swihungwana swa MomConnect eka yona. Xana nomboro leyi yi lulamile?"
+"U nghenisile {{new_number}} tanihi nomboro leyi u lavaka ku kuma swihungwana "
+"swa MomConnect eka yona. Xana nomboro leyi yi lulamile?"
 
 #: go-app-ussd_popi_user_data.js:917
 msgid "No - enter again"
@@ -453,7 +453,7 @@ msgid ""
 "messages on {{channel}}. Thank you for using MomConnect!"
 msgstr ""
 "Nomboro ya wena yi cinciwile kahle eka {{msisdn}}. U ta kuma swihungwana hi "
-"{{chanele}}. Ha khensa ku va u tirhisa MomConnect!"
+"{{channel}}. Ha khensa ku va u tirhisa MomConnect!"
 
 #~ msgid ""
 #~ "Personal info:\n"


### PR DESCRIPTION
For the Tsonga translations for the POPI User Data USSD line, the variable
names have also been translated, which means that it won't be able to render.