### PR TITLE
Change to swt 2 for sms registrations

### DIFF
--- a/go-app-ussd_nurse_rapidpro.js
+++ b/go-app-ussd_nurse_rapidpro.js
@@ -140,7 +140,7 @@ go.OpenHIM = function() {
             })[0].replace("tel:", "");
             return self.http_api.post(url, {data: JSON.stringify({
                 mha: 1,
-                swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 3,
+                swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 2,
                 type: 7,
                 dmsisdn: contact.fields.registered_by,
                 cmsisdn: msisdn,

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -44,7 +44,7 @@ go.OpenHIM = function() {
             })[0].replace("tel:", "");
             return self.http_api.post(url, {data: JSON.stringify({
                 mha: 1,
-                swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 3,
+                swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 2,
                 type: 7,
                 dmsisdn: contact.fields.registered_by,
                 cmsisdn: msisdn,

--- a/test/ussd_nurse_rapidpro.test.js
+++ b/test/ussd_nurse_rapidpro.test.js
@@ -974,7 +974,7 @@ describe('app', function() {
                     api.http.fixtures.add(
                         fixtures_Jembi.nurseconnect_subscription({
                             mha: 1,
-                            swt: 3,
+                            swt: 2,
                             type: 7,
                             dmsisdn: "+27820001002",
                             cmsisdn: "+27820001003",
@@ -1045,7 +1045,7 @@ describe('app', function() {
                     api.http.fixtures.add(
                         fixtures_Jembi.nurseconnect_subscription({
                             mha: 1,
-                            swt: 3,
+                            swt: 2,
                             type: 7,
                             dmsisdn: "+27820001002",
                             cmsisdn: "+27820001003",


### PR DESCRIPTION
Currently we're sending an SWT of 3 for SMS registrations, which is actually
the Android software type. This PR changes this to the correct SWT for SMS,
    which is 2