### PR TITLE
Make optout behaviour more consistent across apps

### DIFF
--- a/go-app-sms_inbound.js
+++ b/go-app-sms_inbound.js
@@ -340,11 +340,19 @@ go.app = function() {
                 "request_source": "sms_inbound",
                 "requestor_source_id": self.im.config.testing_message_id || self.im.msg.message_id
             };
-            return is
-            .optout(optout_info)
-            .then(function() {
-                return self.states.create('state_opt_out');
-            });
+            var optout_change = {
+                "registrant_id": self.im.user.answers.operator.id,
+                "action": "momconnect_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
+                .then(function() {
+                    return self.states.create('state_opt_out');
+                });
         });
 
         self.states.add("state_opt_out", function(name) {

--- a/go-app-sms_pmtct.js
+++ b/go-app-sms_pmtct.js
@@ -161,13 +161,6 @@ go.app = function() {
         });
 
         self.states.add('state_opt_out_enter', function(name) {
-            var optout_change = {
-                "registrant_id": self.im.user.answers.identity_id,
-                "action": "pmtct_nonloss_optout",
-                "data": {
-                    "reason": "unknown"
-                }
-            };
             var optout_info = {
                 optout_type: "stop",  // default to "stop"
                 identity: self.im.user.answers.identity_id,
@@ -177,12 +170,16 @@ go.app = function() {
                 request_source: "sms_pmtct",
                 requestor_source_id: self.im.config.testing_message_id || self.im.msg.message_id,
             };
-            return Q
-                .all([
-                    hub.create_change(optout_change),
-                    is.optout(optout_info),
-                    // self.deactivate_store_vumi_subscriptions(self.im.user.answers.msisdn)
-                ])
+            var optout_change = {
+                "registrant_id": self.im.user.answers.identity_id,
+                "action": "pmtct_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
                 .then(function() {
                     return self.states.create('state_opt_out');
                 });

--- a/go-app-sms_pmtct_seed.js
+++ b/go-app-sms_pmtct_seed.js
@@ -6,7 +6,6 @@ go.app = function() {
     var App = vumigo.App;
     var EndState = vumigo.states.EndState;
     var JsonApi = vumigo.http.api.JsonApi;
-    var Q = require('q');
 
     var SeedJsboxUtils = require('seed-jsbox-utils');
     var IdentityStore = SeedJsboxUtils.IdentityStore;
@@ -83,13 +82,6 @@ go.app = function() {
         });
 
         self.states.add('state_opt_out_enter', function(name) {
-            var optout_change = {
-                "registrant_id": self.im.user.answers.identity_id,
-                "action": "pmtct_nonloss_optout",
-                "data": {
-                    "reason": "unknown"
-                }
-            };
             var optout_info = {
                 optout_type: "stop",  // default to "stop"
                 identity: self.im.user.answers.identity_id,
@@ -99,11 +91,16 @@ go.app = function() {
                 request_source: "sms_pmtct",
                 requestor_source_id: self.im.config.testing_message_id || self.im.msg.message_id,
             };
-            return Q
-                .all([
-                    hub.create_change(optout_change),
-                    is.optout(optout_info),
-                ])
+            var optout_change = {
+                "registrant_id": self.im.user.answers.identity_id,
+                "action": "pmtct_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
                 .then(function() {
                     return self.states.create('state_opt_out');
                 });

--- a/src/sms_inbound.js
+++ b/src/sms_inbound.js
@@ -190,11 +190,19 @@ go.app = function() {
                 "request_source": "sms_inbound",
                 "requestor_source_id": self.im.config.testing_message_id || self.im.msg.message_id
             };
-            return is
-            .optout(optout_info)
-            .then(function() {
-                return self.states.create('state_opt_out');
-            });
+            var optout_change = {
+                "registrant_id": self.im.user.answers.operator.id,
+                "action": "momconnect_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
+                .then(function() {
+                    return self.states.create('state_opt_out');
+                });
         });
 
         self.states.add("state_opt_out", function(name) {

--- a/src/sms_pmtct.js
+++ b/src/sms_pmtct.js
@@ -158,13 +158,6 @@ go.app = function() {
         });
 
         self.states.add('state_opt_out_enter', function(name) {
-            var optout_change = {
-                "registrant_id": self.im.user.answers.identity_id,
-                "action": "pmtct_nonloss_optout",
-                "data": {
-                    "reason": "unknown"
-                }
-            };
             var optout_info = {
                 optout_type: "stop",  // default to "stop"
                 identity: self.im.user.answers.identity_id,
@@ -174,12 +167,16 @@ go.app = function() {
                 request_source: "sms_pmtct",
                 requestor_source_id: self.im.config.testing_message_id || self.im.msg.message_id,
             };
-            return Q
-                .all([
-                    hub.create_change(optout_change),
-                    is.optout(optout_info),
-                    // self.deactivate_store_vumi_subscriptions(self.im.user.answers.msisdn)
-                ])
+            var optout_change = {
+                "registrant_id": self.im.user.answers.identity_id,
+                "action": "pmtct_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
                 .then(function() {
                     return self.states.create('state_opt_out');
                 });

--- a/src/sms_pmtct_seed.js
+++ b/src/sms_pmtct_seed.js
@@ -3,7 +3,6 @@ go.app = function() {
     var App = vumigo.App;
     var EndState = vumigo.states.EndState;
     var JsonApi = vumigo.http.api.JsonApi;
-    var Q = require('q');
 
     var SeedJsboxUtils = require('seed-jsbox-utils');
     var IdentityStore = SeedJsboxUtils.IdentityStore;
@@ -80,13 +79,6 @@ go.app = function() {
         });
 
         self.states.add('state_opt_out_enter', function(name) {
-            var optout_change = {
-                "registrant_id": self.im.user.answers.identity_id,
-                "action": "pmtct_nonloss_optout",
-                "data": {
-                    "reason": "unknown"
-                }
-            };
             var optout_info = {
                 optout_type: "stop",  // default to "stop"
                 identity: self.im.user.answers.identity_id,
@@ -96,11 +88,16 @@ go.app = function() {
                 request_source: "sms_pmtct",
                 requestor_source_id: self.im.config.testing_message_id || self.im.msg.message_id,
             };
-            return Q
-                .all([
-                    hub.create_change(optout_change),
-                    is.optout(optout_info),
-                ])
+            var optout_change = {
+                "registrant_id": self.im.user.answers.identity_id,
+                "action": "pmtct_nonloss_optout",
+                "data": {
+                    "reason": "unknown",
+                    "identity_store_optout": optout_info
+                }
+            };
+            return hub
+                .create_change(optout_change)
                 .then(function() {
                     return self.states.create('state_opt_out');
                 });

--- a/test/fixtures_hub.js
+++ b/test/fixtures_hub.js
@@ -675,7 +675,16 @@ module.exports = function() {
                     "registrant_id": "cb245673-aa41-4302-ac47-00000001002",
                     "action": "momconnect_nonloss_optout",
                     "data": {
-                        "reason": "miscarriage"
+                        "reason": "unknown",
+                        "identity_store_optout": {
+                            "optout_type": "stop",
+                            "identity": "cb245673-aa41-4302-ac47-00000001002",
+                            "reason": "unknown",
+                            "address_type": "msisdn",
+                            "address": "+27820001002",
+                            "request_source": "sms_inbound",
+                            "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
+                        }
                     }
                 }
             },

--- a/test/fixtures_hub.js
+++ b/test/fixtures_hub.js
@@ -12,7 +12,16 @@ module.exports = function() {
                     "registrant_id": "cb245673-aa41-4302-ac47-00000000001",
                     "action": "pmtct_nonloss_optout",
                     "data": {
-                        "reason": "unknown"
+                        "reason": "unknown",
+                        "identity_store_optout": {
+                            "optout_type": "stop",
+                            "identity": "cb245673-aa41-4302-ac47-00000000001",
+                            "reason": "unknown",
+                            "address_type": "msisdn",
+                            "address": "+27820000111",
+                            "request_source": "sms_pmtct",
+                            "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
+                        }
                     }
                 }
             },

--- a/test/fixtures_identity_store.js
+++ b/test/fixtures_identity_store.js
@@ -535,28 +535,16 @@ module.exports = function() {
             }
         },
 
-        // 194: optout (sms_inbound) identity cb245673-aa41-4302-ac47-00000001002
+        // 194: unused
         {
-            "key": "post.is.optout.identity.cb245673-aa41-4302-ac47-00000001002",
             "request": {
-                "url": 'http://is/api/v1/optout/',
                 "method": 'POST',
                 "data": {
-                    "optout_type": "stop",
-                    "identity": "cb245673-aa41-4302-ac47-00000001002",
-                    "reason": "unknown",
-                    "address_type": "msisdn",
-                    "address": "+27820001002",
-                    "request_source": "sms_inbound",
-                    "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
-                }
+                    "deprecated": "fixture"
+                },
+                "url": 'http://'
             },
-            "response": {
-                "code": 201,
-                "data": {
-                    "accepted": true
-                }
-            }
+            "response": {}
         },
 
         // 195: optin identity cb245673-aa41-4302-ac47-00000001002

--- a/test/fixtures_identity_store.js
+++ b/test/fixtures_identity_store.js
@@ -1572,23 +1572,13 @@ module.exports = function() {
             'response': {}
         },
 
-        // 223: optout cb245673-aa41-4302-ac47-00000000001 (sms_pmtct)
+        // 223: unused
         {
-            "key": "post.is.optout.stop.identity.cb245673-aa41-4302-ac47-00000000001",
-            "request": {
-                "url": "http://is/api/v1/optout/",
-                "method": 'POST',
-                "data": {
-                    "optout_type": "stop",
-                    "identity": "cb245673-aa41-4302-ac47-00000000001",
-                    "reason": "unknown",
-                    "address_type": "msisdn",
-                    "address": "+27820000111",
-                    "request_source": "sms_pmtct",
-                    "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
-                }
+            'request': {
+                'method': 'GET',
+                'url': 'http://',
             },
-            "response": {}
+            'response': {}
         },
 
         // 224: get identity by msisdn +27820001012

--- a/test/fixtures_pmtct.js
+++ b/test/fixtures_pmtct.js
@@ -2974,26 +2974,19 @@ module.exports = function() {
             "response": {}
         },
 
-        // 77: optout cb245673-aa41-4302-ac47-00000000001 (sms_pmtct)
+        // 77: unused
         {
-            "key": "post.is.optout.stop.identity.cb245673-aa41-4302-ac47-00000000001",
             "request": {
-                "url": "http://is/api/v1/optout/",
                 "method": 'POST',
                 "data": {
-                    "optout_type": "stop",
-                    "identity": "cb245673-aa41-4302-ac47-00000000001",
-                    "reason": "unknown",
-                    "address_type": "msisdn",
-                    "address": "+27820000111",
-                    "request_source": "sms_pmtct",
-                    "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
-                }
+                    "deprecated": "fixture"
+                },
+                "url": 'http://'
             },
             "response": {}
         },
 
-        // 78:
+        // 78: optout cb245673-aa41-4302-ac47-00000000001 (sms_pmtct)
         {
             "key": "post.hub.change.pmtct_nonloss_optout.unknown.identity.cb245673-aa41-4302-ac47-00000000001",
             "request": {
@@ -3003,7 +2996,16 @@ module.exports = function() {
                     "registrant_id": "cb245673-aa41-4302-ac47-00000000001",
                     "action": "pmtct_nonloss_optout",
                     "data": {
-                        "reason": "unknown"
+                        "reason": "unknown",
+                        "identity_store_optout": {
+                            "optout_type": "stop",
+                            "identity": "cb245673-aa41-4302-ac47-00000000001",
+                            "reason": "unknown",
+                            "address_type": "msisdn",
+                            "address": "+27820000111",
+                            "request_source": "sms_pmtct",
+                            "requestor_source_id": "0170b7bb-978e-4b8a-35d2-662af5b6daee"
+                        }
                     }
                 }
             },

--- a/test/sms_inbound.test.js
+++ b/test/sms_inbound.test.js
@@ -282,7 +282,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });
@@ -297,7 +297,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });
@@ -312,7 +312,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });
@@ -327,7 +327,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });
@@ -342,7 +342,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });
@@ -357,7 +357,7 @@ describe("app", function() {
                             'If you have any medical concerns please visit your nearest clinic'
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [51, 54, 181, 194]);
+                        utils.check_fixtures_used(api, [26, 51, 54, 181]);
                     })
                     .run();
             });

--- a/test/sms_pmtct.test.js
+++ b/test/sms_pmtct.test.js
@@ -88,7 +88,7 @@ describe("app", function() {
                     })
                     .check(function(api) {
                         // utils.check_fixtures_used(api, [0, 58, 59, 60, 77, 78]);
-                        utils.check_fixtures_used(api, [0, 77, 78]);
+                        utils.check_fixtures_used(api, [0, 78]);
                     })
                     .run();
             });

--- a/test/sms_pmtct_seed.test.js
+++ b/test/sms_pmtct_seed.test.js
@@ -92,7 +92,7 @@ describe("app", function() {
                             "about your pregnancy or baby."
                     })
                     .check(function(api) {
-                        utils.check_fixtures_used(api, [0, 210, 223]);
+                        utils.check_fixtures_used(api, [0, 210]);
                     })
                     .run();
             });


### PR DESCRIPTION
SMS optouts are not working as intended because they are not posting the Change to the Hub, so the subscriptions aren't being deactivated.

There is no need to create the Optout in the Identity Store because the task in the Hub that validates Changes will deactivate the subscriptions and forward the Optout data to the Identity Store if it is provided
https://github.com/praekeltfoundation/ndoh-hub/blob/develop/changes/tasks.py#L1179

Opting out via the ussd lines creates a Change but does not provide data to forward to the Identity Store.
I'm not sure if it should. (exception is the popi-user-data line which creates a 'forget' Optout)