### PR TITLE
Send sid and eid to OpenHIM

### DIFF
--- a/go-app-ussd_nurse_rapidpro.js
+++ b/go-app-ussd_nurse_rapidpro.js
@@ -132,16 +132,31 @@ go.OpenHIM = function() {
             }
         };
 
-        self.submit_nc_registration = function(contact) {
+        self.uuidv4 = function(mock) {
+            if(mock !== undefined) {
+                return mock;
+            }
+            // From https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+              var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+              return v.toString(16);
+            });
+        };
+
+        self.submit_nc_registration = function(contact, mock_eid) {
             var url = self.base_url + "nc/subscription";
             var msisdn = contact.urns.filter(function(urn) {
                 // Starts with tel:
                 return urn.search('tel:') == 0;
             })[0].replace("tel:", "");
+            // We don't retry this HTTP request, so we can generate a random event ID
+            var eid = self.uuidv4(mock_eid);
             return self.http_api.post(url, {data: JSON.stringify({
                 mha: 1,
                 swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 1,
                 type: 7,
+                sid: contact.uuid,
+                eid: eid,
                 dmsisdn: contact.fields.registered_by,
                 cmsisdn: msisdn,
                 rmsisdn: null,
@@ -509,7 +524,7 @@ go.app = function() {
                 // Send registration to DHIS2
                 .then(function() {
                     var contact = self.im.user.get_answer("registrant_contact");
-                    return self.openhim.submit_nc_registration(contact);
+                    return self.openhim.submit_nc_registration(contact, self.im.config.mock_eid);
                 })
                 .then(function() {
                     return self.states.create("state_registration_complete");

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -36,16 +36,31 @@ go.OpenHIM = function() {
             }
         };
 
-        self.submit_nc_registration = function(contact) {
+        self.uuidv4 = function(mock) {
+            if(mock !== undefined) {
+                return mock;
+            }
+            // From https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+              var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+              return v.toString(16);
+            });
+        };
+
+        self.submit_nc_registration = function(contact, mock_eid) {
             var url = self.base_url + "nc/subscription";
             var msisdn = contact.urns.filter(function(urn) {
                 // Starts with tel:
                 return urn.search('tel:') == 0;
             })[0].replace("tel:", "");
+            // We don't retry this HTTP request, so we can generate a random event ID
+            var eid = self.uuidv4(mock_eid);
             return self.http_api.post(url, {data: JSON.stringify({
                 mha: 1,
                 swt: contact.fields.preferred_channel === "whatsapp" ? 7 : 1,
                 type: 7,
+                sid: contact.uuid,
+                eid: eid,
                 dmsisdn: contact.fields.registered_by,
                 cmsisdn: msisdn,
                 rmsisdn: null,

--- a/src/ussd_nurse_rapidpro.js
+++ b/src/ussd_nurse_rapidpro.js
@@ -349,7 +349,7 @@ go.app = function() {
                 // Send registration to DHIS2
                 .then(function() {
                     var contact = self.im.user.get_answer("registrant_contact");
-                    return self.openhim.submit_nc_registration(contact);
+                    return self.openhim.submit_nc_registration(contact, self.im.config.mock_eid);
                 })
                 .then(function() {
                     return self.states.create("state_registration_complete");

--- a/test/ussd_nurse_rapidpro.test.js
+++ b/test/ussd_nurse_rapidpro.test.js
@@ -35,6 +35,7 @@ describe('app', function() {
                             token: 'somethingsecret'
                         }
                     },
+                    mock_eid: "mock-event-id"
                 });
         });
 
@@ -941,6 +942,8 @@ describe('app', function() {
                             mha: 1,
                             swt: 7,
                             type: 7,
+                            eid: "mock-event-id",
+                            sid: "contact-uuid",
                             dmsisdn: "+27820001002",
                             cmsisdn: "+27820001003",
                             rmsisdn: null,
@@ -1003,6 +1006,8 @@ describe('app', function() {
                             mha: 1,
                             swt: 1,
                             type: 7,
+                            eid: "mock-event-id",
+                            sid: "contact-uuid",
                             dmsisdn: "+27820001002",
                             cmsisdn: "+27820001003",
                             rmsisdn: null,
@@ -1074,6 +1079,8 @@ describe('app', function() {
                             mha: 1,
                             swt: 1,
                             type: 7,
+                            eid: "mock-event-id",
+                            sid: "contact-uuid",
                             dmsisdn: "+27820001002",
                             cmsisdn: "+27820001003",
                             rmsisdn: null,


### PR DESCRIPTION
We need to send the SystemID `sid` parameter (the Contact UUID) as well as the EventID `eid` parameter (any UUID unique to the event) in order for us to be able to retry requests and have deduplication.

In this case, since the request is done in the USSD session, we cannot afford to have retries, so we just generate a random UUID for the event ID.