### PR TITLE
Remove calls to get list of flows from RapidPro

### DIFF
--- a/go-app-ussd_nurse_rapidpro.js
+++ b/go-app-ussd_nurse_rapidpro.js
@@ -195,6 +195,7 @@ go.app = function() {
     var utils = SeedJsboxUtils.utils;
     var App = vumigo.App;
     var moment = require('moment');
+    var Q = require('q');
 
     var GoNDOH = App.extend(function(self) {
         App.call(self, 'state_start');
@@ -518,15 +519,10 @@ go.app = function() {
                         });
                     }
                 })
-                // Find the post registration flow
+                // Start the post registration flow for the user
                 .then(function(contact) {
                     self.im.user.set_answer("registrant_contact", contact);
-                    return self.rapidpro.get_flow_by_name("post registration");
-                })
-                // Start the post registration flow for the user
-                .then(function(flow) {
-                    var contact = self.im.user.get_answer("registrant_contact");
-                    return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                    return self.rapidpro.start_flow(self.im.config.rapidpro.registration_flow_id, contact.uuid);
                 })
                 // Send registration to DHIS2
                 .then(function() {
@@ -594,10 +590,7 @@ go.app = function() {
                 }
             })
             .then(function() {
-                return self.rapidpro.get_flow_by_name('Optout');
-            })
-            .then(function(flow) {
-                return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                return self.rapidpro.start_flow(self.im.config.rapidpro.optout_flow_id, contact.uuid);
             })
             .then(function() {
                 return self.states.create("state_opted_out");
@@ -840,9 +833,9 @@ go.app = function() {
                     }
 
                     var contact = self.im.user.get_answer('old_contact');
-                    return self.rapidpro.get_flow_by_name('Optin')
-                    .then(function(flow) {
-                        return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                    return Q()
+                    .then(function() {
+                        return self.rapidpro.start_flow(self.im.config.rapidpro.optin_flow_id, contact.uuid);
                     })
                     .then(function() {
                         return choice.value;

--- a/src/ussd_nurse_rapidpro.js
+++ b/src/ussd_nurse_rapidpro.js
@@ -13,6 +13,7 @@ go.app = function() {
     var utils = SeedJsboxUtils.utils;
     var App = vumigo.App;
     var moment = require('moment');
+    var Q = require('q');
 
     var GoNDOH = App.extend(function(self) {
         App.call(self, 'state_start');
@@ -336,15 +337,10 @@ go.app = function() {
                         });
                     }
                 })
-                // Find the post registration flow
+                // Start the post registration flow for the user
                 .then(function(contact) {
                     self.im.user.set_answer("registrant_contact", contact);
-                    return self.rapidpro.get_flow_by_name("post registration");
-                })
-                // Start the post registration flow for the user
-                .then(function(flow) {
-                    var contact = self.im.user.get_answer("registrant_contact");
-                    return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                    return self.rapidpro.start_flow(self.im.config.rapidpro.registration_flow_id, contact.uuid);
                 })
                 // Send registration to DHIS2
                 .then(function() {
@@ -412,10 +408,7 @@ go.app = function() {
                 }
             })
             .then(function() {
-                return self.rapidpro.get_flow_by_name('Optout');
-            })
-            .then(function(flow) {
-                return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                return self.rapidpro.start_flow(self.im.config.rapidpro.optout_flow_id, contact.uuid);
             })
             .then(function() {
                 return self.states.create("state_opted_out");
@@ -658,9 +651,9 @@ go.app = function() {
                     }
 
                     var contact = self.im.user.get_answer('old_contact');
-                    return self.rapidpro.get_flow_by_name('Optin')
-                    .then(function(flow) {
-                        return self.rapidpro.start_flow(flow.uuid, contact.uuid);
+                    return Q()
+                    .then(function() {
+                        return self.rapidpro.start_flow(self.im.config.rapidpro.optin_flow_id, contact.uuid);
                     })
                     .then(function() {
                         return choice.value;

--- a/test/ussd_nurse_rapidpro.test.js
+++ b/test/ussd_nurse_rapidpro.test.js
@@ -35,6 +35,11 @@ describe('app', function() {
                             token: 'somethingsecret'
                         }
                     },
+                    rapidpro: {
+                        registration_flow_id: "post-registration-flow-uuid",
+                        optout_flow_id: "optout-flow-uuid",
+                        optin_flow_id: "optin-flow-uuid"
+                    },
                     mock_eid: "mock-event-id"
                 });
         });
@@ -163,12 +168,6 @@ describe('app', function() {
                                         })
                                     );
                                     api.http.fixtures.add(
-                                        fixtures_RapidPro.get_flows([{
-                                            uuid: 'optout-flow-uuid',
-                                            name: "Optout"
-                                        }])
-                                    );
-                                    api.http.fixtures.add(
                                         fixtures_RapidPro.start_flow("optout-flow-uuid", "operator-contact-uuid")
                                     );
                                 })
@@ -183,7 +182,7 @@ describe('app', function() {
                                     })
                                 .check.reply.ends_session()
                                 .check(function(api) {
-                                    utils.check_fixtures_used(api, [0, 1, 2]);
+                                    utils.check_fixtures_used(api, [0, 1]);
                                 })
                                 .run();
                         });
@@ -928,12 +927,6 @@ describe('app', function() {
                         }, "contact-uuid")
                     );
                     api.http.fixtures.add(
-                        fixtures_RapidPro.get_flows([{
-                            uuid: "post-registration-flow-uuid",
-                            name: "Post registration"
-                        }])
-                    );
-                    api.http.fixtures.add(
                         fixtures_RapidPro.start_flow(
                             "post-registration-flow-uuid", "contact-uuid")
                     );
@@ -964,7 +957,7 @@ describe('app', function() {
                            "You'll get 3 messages every week."
                 })
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [0, 1, 2, 3, 4]);
+                    utils.check_fixtures_used(api, [0, 1, 2, 3]);
                 })
                 .run();
         });
@@ -990,12 +983,6 @@ describe('app', function() {
                                 registration_date: "2014-04-04T07:07:07Z"
                             }
                         }, "contact-uuid")
-                    );
-                    api.http.fixtures.add(
-                        fixtures_RapidPro.get_flows([{
-                            uuid: "post-registration-flow-uuid",
-                            name: "Post registration"
-                        }])
                     );
                     api.http.fixtures.add(
                         fixtures_RapidPro.start_flow(
@@ -1028,7 +1015,7 @@ describe('app', function() {
                            "You'll get 3 messages every week."
                 })
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [0, 1, 2, 3, 4]);
+                    utils.check_fixtures_used(api, [0, 1, 2, 3]);
                 })
                 .run();
         });
@@ -1065,12 +1052,6 @@ describe('app', function() {
                         })
                     );
                     api.http.fixtures.add(
-                        fixtures_RapidPro.get_flows([{
-                            uuid: "post-registration-flow-uuid",
-                            name: "Post registration"
-                        }])
-                    );
-                    api.http.fixtures.add(
                         fixtures_RapidPro.start_flow(
                             "post-registration-flow-uuid", "contact-uuid")
                     );
@@ -1101,7 +1082,7 @@ describe('app', function() {
                            "You'll get 3 messages every week."
                 })
                 .check(function(api) {
-                    utils.check_fixtures_used(api, [0, 1, 2, 3, 4]);
+                    utils.check_fixtures_used(api, [0, 1, 2, 3]);
                 })
                 .run();
         });
@@ -1435,12 +1416,6 @@ describe('app', function() {
             .setup.user.addr("0820001002")
             .setup(function(api) {
                 api.http.fixtures.add(
-                    fixtures_RapidPro.get_flows([{
-                        uuid: "optin-flow-uuid",
-                        name: "Optin"
-                    }])
-                );
-                api.http.fixtures.add(
                     fixtures_RapidPro.start_flow("optin-flow-uuid", "existing-contact-uuid")
                 );
                 api.http.fixtures.add(
@@ -1460,7 +1435,7 @@ describe('app', function() {
             })
             .check.reply.ends_session()
             .check(function(api){
-                utils.check_fixtures_used(api, [0, 1, 2]);
+                utils.check_fixtures_used(api, [0, 1]);
             })
             .run();
         });


### PR DESCRIPTION
Currently, we have enough flows that we're hitting the body size limits of HTTP requests in the sandbox.

These calls to get the list of flows isn't necessary, we can just put the flow ID into the application config, and skip the HTTP call