### PR TITLE
Add more information on rapidpro trigger for number change

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -492,7 +492,9 @@ go.app = function() {
                 .start_flow(
                     self.im.config.msisdn_change_flow_id, null, "tel:" + new_msisdn, {
                         new_msisdn: new_msisdn,
-                        contact_uuid: self.im.user.answers.contact.uuid
+                        old_msisdn: utils.normalize_msisdn(self.im.user.addr, "ZA"),
+                        contact_uuid: self.im.user.answers.contact.uuid,
+                        source: "POPI USSD"
                     }
                 )
                 .then(function() {

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -389,7 +389,9 @@ go.app = function() {
                 .start_flow(
                     self.im.config.msisdn_change_flow_id, null, "tel:" + new_msisdn, {
                         new_msisdn: new_msisdn,
-                        contact_uuid: self.im.user.answers.contact.uuid
+                        old_msisdn: utils.normalize_msisdn(self.im.user.addr, "ZA"),
+                        contact_uuid: self.im.user.answers.contact.uuid,
+                        source: "POPI USSD"
                     }
                 )
                 .then(function() {

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -501,7 +501,9 @@ describe("ussd_popi_rapidpro app", function() {
                         fixtures_rapidpro.start_flow(
                             "msisdn-change-flow", null, "tel:+27820001001", {
                                 new_msisdn: "+27820001001",
-                                contact_uuid: "contact-uuid"
+                                old_msisdn: "+27123456789",
+                                contact_uuid: "contact-uuid",
+                                source: "POPI USSD"
                             }
                         )
                     );


### PR DESCRIPTION
This PR adds the `old_msisdn` and `source` fields, which we will need in the rapidpro flow.