### PR TITLE
Fix null contact field handling

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -159,7 +159,7 @@ go.app = function() {
 
         self.contact_current_channel = function(contact) {
             // Returns the current channel of the contact
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel", "")) === "WHATSAPP") {
                 return $("WhatsApp");
             } else {
                 return $("SMS");
@@ -168,7 +168,7 @@ go.app = function() {
 
         self.contact_alternative_channel = function(contact) {
             // Returns the alternative channel of the contact
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel", "")) === "WHATSAPP") {
                 return $("SMS");
             } else {
                 return $("WhatsApp");
@@ -194,7 +194,7 @@ go.app = function() {
                 .then(function(contact) {
                     self.im.user.set_answer("contact", contact);
                     // Set the language if we have it
-                    if(_.isString(_.get(contact, "language"))) {
+                    if(_.get(self.languages, _.get(contact, "language"))) {
                         return self.im.user.set_lang(contact.language);
                     }
                 }).then(function() {
@@ -236,7 +236,7 @@ go.app = function() {
                 "Baby's birthday: {{dobs}}"
             ].join("\n")).context({
                 msisdn: utils.readable_msisdn(self.im.user.addr, "27"),
-                channel: _.get(contact, "fields.preferred_channel", $("None")),
+                channel: _.get(contact, "fields.preferred_channel") || $("None"),
                 language: _.get(self.languages, _.get(contact, "language"), $("None")),
                 id_type: _.get({
                     passport: $("Passport"),
@@ -262,7 +262,7 @@ go.app = function() {
                     _.get({
                         "TRUE": $("Yes"),
                         "FALSE": $("No")
-                    }, _.get(contact, "fields.research_consent", "").toUpperCase(), $("None")),
+                    }, _.toUpper(_.get(contact, "fields.research_consent")), $("None")),
                 dobs: _.map(_.filter([
                     new moment(_.get(contact, "fields.baby_dob1", null)),
                     new moment(_.get(contact, "fields.baby_dob2", null)),
@@ -337,7 +337,7 @@ go.app = function() {
 
         self.add("state_channel_switch", function(name, opts) {
             var contact = self.im.user.answers.contact, flow_uuid;
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
                 flow_uuid = self.im.config.sms_switch_flow_id;
             } else {
                 flow_uuid = self.im.config.whatsapp_switch_flow_id;

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -56,7 +56,7 @@ go.app = function() {
 
         self.contact_current_channel = function(contact) {
             // Returns the current channel of the contact
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel", "")) === "WHATSAPP") {
                 return $("WhatsApp");
             } else {
                 return $("SMS");
@@ -65,7 +65,7 @@ go.app = function() {
 
         self.contact_alternative_channel = function(contact) {
             // Returns the alternative channel of the contact
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel", "")) === "WHATSAPP") {
                 return $("SMS");
             } else {
                 return $("WhatsApp");
@@ -91,7 +91,7 @@ go.app = function() {
                 .then(function(contact) {
                     self.im.user.set_answer("contact", contact);
                     // Set the language if we have it
-                    if(_.isString(_.get(contact, "language"))) {
+                    if(_.get(self.languages, _.get(contact, "language"))) {
                         return self.im.user.set_lang(contact.language);
                     }
                 }).then(function() {
@@ -133,7 +133,7 @@ go.app = function() {
                 "Baby's birthday: {{dobs}}"
             ].join("\n")).context({
                 msisdn: utils.readable_msisdn(self.im.user.addr, "27"),
-                channel: _.get(contact, "fields.preferred_channel", $("None")),
+                channel: _.get(contact, "fields.preferred_channel") || $("None"),
                 language: _.get(self.languages, _.get(contact, "language"), $("None")),
                 id_type: _.get({
                     passport: $("Passport"),
@@ -159,7 +159,7 @@ go.app = function() {
                     _.get({
                         "TRUE": $("Yes"),
                         "FALSE": $("No")
-                    }, _.get(contact, "fields.research_consent", "").toUpperCase(), $("None")),
+                    }, _.toUpper(_.get(contact, "fields.research_consent")), $("None")),
                 dobs: _.map(_.filter([
                     new moment(_.get(contact, "fields.baby_dob1", null)),
                     new moment(_.get(contact, "fields.baby_dob2", null)),
@@ -234,7 +234,7 @@ go.app = function() {
 
         self.add("state_channel_switch", function(name, opts) {
             var contact = self.im.user.answers.contact, flow_uuid;
-            if(_.get(contact, "fields.preferred_channel", "").toUpperCase() === "WHATSAPP") {
+            if(_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
                 flow_uuid = self.im.config.sms_switch_flow_id;
             } else {
                 flow_uuid = self.im.config.whatsapp_switch_flow_id;

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -127,6 +127,19 @@ describe("ussd_popi_rapidpro app", function() {
         it("should handle missing contact fields", function() {
             return tester
                 .setup.user.state("state_personal_info")
+                .setup.user.answer("contact", {
+                    language: null,
+                    groups: [],
+                    fields: {
+                        preferred_channel: null,
+                        identification_type: null,
+                        research_consent: null,
+                        baby_dob1: null,
+                        baby_dob2: null,
+                        baby_dob3: null,
+                        edd: null
+                    }
+                })
                 .check.interaction({
                     reply: [
                         "Cell number: 0123456789",


### PR DESCRIPTION
If RapidPro doesn't have a value for a field for a contact, then it will still have that field in the API response, but its value will be `null`, so we should handle that.