### PR TITLE
Fix msisdn and fields on PMTCT flow start

### DIFF
--- a/go-app-ussd_pmtct_rapidpro.js
+++ b/go-app-ussd_pmtct_rapidpro.js
@@ -202,8 +202,6 @@ go.app = function() {
                 }).then(function() {
                     // Delegate to the correct state depending on contact fields
                     var contact = self.im.user.get_answer("contact");
-                    console.log(_.get(contact, "fields.prebirth_messaging"));
-                    console.log(_.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7));
                     if(_.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7)) {
                         if(_.toUpper(_.get(contact, "fields.pmtct_messaging")) === "TRUE") {
                             return self.states.create("state_optout");
@@ -443,6 +441,7 @@ go.app = function() {
             var dob;
             var swt = 1;
             var contact = self.im.user.get_answer("contact");
+            var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             var babyloss_subscription = self.im.user.get_answer("state_loss_optout") === "yes" ? "TRUE" : "FALSE";
             if(_.isString(_.get(contact, "fields.dob"))) {
                 dob = moment.utc(contact.fields.dob).format();
@@ -459,7 +458,6 @@ go.app = function() {
                 swt = _.toUpper(contact.fields.preferred_channel) === "WHATSAPP" ? 7 : 1;
             }
 
-            var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             if (self.im.user.get_answer("state_enter_msisdn")) {
                 msisdn = utils.normalize_msisdn(self.im.user.get_answer("state_enter_msisdn"), "ZA");
             }

--- a/src/ussd_pmtct_rapidpro.js
+++ b/src/ussd_pmtct_rapidpro.js
@@ -171,7 +171,7 @@ go.app = function() {
                         return "state_loss_optout";
                     } else {
                         return "state_trigger_rapidpro_flow";
-                      }  
+                      }
                 }
             });
         });
@@ -229,7 +229,7 @@ go.app = function() {
                         }
                         else{
                             return "state_dob_year";
-                        }  
+                        }
                     }
                     else {
                         return "state_no_registration";
@@ -299,9 +299,9 @@ go.app = function() {
                     if(
                         !match ||
                         !(dob = new moment(
-                            self.im.user.answers.state_dob_year + 
-                            self.im.user.answers.state_dob_month + 
-                            match[1], 
+                            self.im.user.answers.state_dob_year +
+                            self.im.user.answers.state_dob_month +
+                            match[1],
                             "YYYYMMDD")
                         ) ||
                         !dob.isValid()
@@ -336,27 +336,39 @@ go.app = function() {
 
         self.add("state_trigger_rapidpro_flow", function(name, opts) {
             var dob;
+            var swt = 1;
             var contact = self.im.user.get_answer("contact");
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             var babyloss_subscription = self.im.user.get_answer("state_loss_optout") === "yes" ? "TRUE" : "FALSE";
             if(_.isString(_.get(contact, "fields.dob"))) {
                 dob = moment.utc(contact.fields.dob).format();
-            } 
-            else { 
-                dob = new moment.utc(
-                self.im.user.answers.state_dob_year +
-                self.im.user.answers.state_dob_month +
-                self.im.user.answers.state_dob_day,
-                "YYYYMMDD"
-            ).format();
             }
+            else {
+                dob = new moment.utc(
+                    self.im.user.answers.state_dob_year +
+                    self.im.user.answers.state_dob_month +
+                    self.im.user.answers.state_dob_day,
+                    "YYYYMMDD"
+                ).format();
+            }
+            if(_.isString(_.get(contact, "fields.preferred_channel"))) {
+                swt = _.toUpper(contact.fields.preferred_channel) === "WHATSAPP" ? 7 : 1;
+            }
+
+            if (self.im.user.get_answer("state_enter_msisdn")) {
+                msisdn = utils.normalize_msisdn(self.im.user.get_answer("state_enter_msisdn"), "ZA");
+            }
+
             return self.rapidpro.start_flow(self.im.config.flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"), {
                 dob: dob,
                 optout_reason: self.im.user.get_answer("state_optout_reason"),
                 babyloss_subscription: babyloss_subscription,
-                optout: 
+                optout:
                     self.im.user.get_answer("state_optout") === "yes" ? "TRUE" : "FALSE",
                 source: "PMTCT USSD",
+                registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
+                mha: 1,
+                swt: swt,
             }).then(function() {
                 if ((self.im.user.get_answer("state_optout") === "yes") && babyloss_subscription === "FALSE"){
                     return self.states.create("state_opted_out");
@@ -364,7 +376,7 @@ go.app = function() {
                     return self.states.create("state_loss_subscription");
                 }
                 else{
-                    return self.states.create("state_end_registration"); 
+                    return self.states.create("state_end_registration");
                 }
             }).catch(function(e) {
                 // Go to error state after 3 failed HTTP requests

--- a/test/ussd_pmtct_rapidpro.test.js
+++ b/test/ussd_pmtct_rapidpro.test.js
@@ -160,7 +160,7 @@ describe("ussd_pmtct app", function() {
                 .setup.user.state("state_check_subscription")
                 .check.interaction({
                     state: "__error__",
-                    reply: 
+                    reply:
                         "Sorry, something went wrong. We have been notified. Please try again " +
                         "later"
                 })
@@ -220,7 +220,7 @@ describe("ussd_pmtct app", function() {
                 .input("2")
                 .check.interaction({
                     state: "state_no_optout",
-                    reply: 
+                    reply:
                     "Thanks! MomConnect will continue to send HER helpful messages and process your " +
                     "personal info."
                 })
@@ -273,8 +273,12 @@ describe("ussd_pmtct app", function() {
                 .setup.user.state("state_optout_reason")
                 .setup.user.answers({
                     state_optout: "yes",
+                    state_enter_msisdn: "0712221111",
                     contact: {
-                        fields: {dob: "1990-01-01T00:00:00"}
+                        fields: {
+                            dob: "1990-01-01T00:00:00",
+                            preferred_channel: "WhatsApp"
+                        }
                     }
                 })
                 .setup(function(api) {
@@ -282,13 +286,16 @@ describe("ussd_pmtct app", function() {
                         fixtures_rapidpro.start_flow(
                             "rapidpro-flow-uuid",
                             null,
-                            "whatsapp:27123456789",
+                            "whatsapp:27712221111",
                             {
                                 babyloss_subscription: "FALSE",
                                 optout: "TRUE",
                                 optout_reason: "not_useful",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 7,
                             }
                         )
                     );
@@ -371,6 +378,9 @@ describe("ussd_pmtct app", function() {
                                 optout: "TRUE",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -405,6 +415,9 @@ describe("ussd_pmtct app", function() {
                                 optout: "TRUE",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -465,7 +478,10 @@ describe("ussd_pmtct app", function() {
                                 babyloss_subscription: "FALSE",
                                 dob: "1990-01-01T00:00:00Z",
                                 optout: "FALSE",
-                                source: "PMTCT USSD"
+                                source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -502,7 +518,7 @@ describe("ussd_pmtct app", function() {
                 .setup.user.state("state_dob_year")
                 .input("22")
                 .check.interaction({
-                    reply: 
+                    reply:
                         "Sorry, we don't understand. Please try again by entering the year " +
                         "she was born as 4 digits in the format YYYY, e.g. 1910."
                 })
@@ -606,7 +622,10 @@ describe("ussd_pmtct app", function() {
                                 dob: "1987-02-22T00:00:00Z",
                                 babyloss_subscription: "FALSE",
                                 optout:"FALSE",
-                                source: "PMTCT USSD"
+                                source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -635,7 +654,10 @@ describe("ussd_pmtct app", function() {
                                 dob: "1990-01-01T00:00:00Z",
                                 babyloss_subscription: "FALSE",
                                 optout: "FALSE",
-                                source: "PMTCT USSD"
+                                source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -643,7 +665,7 @@ describe("ussd_pmtct app", function() {
                 .input({session_event: "continue"})
                 .check.interaction({
                     state: "state_end_registration",
-                    reply: 
+                    reply:
                         "Thank you. The mother will receive messages about keeping her baby " +
                         "HIV-negative. Have a lovely day."
                 })
@@ -672,6 +694,9 @@ describe("ussd_pmtct app", function() {
                                 optout_reason: "other",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -679,7 +704,7 @@ describe("ussd_pmtct app", function() {
                 .input({session_event: "continue"})
                 .check.interaction({
                     state: "state_opted_out",
-                    reply: 
+                    reply:
                         "Thank you. She will no longer receive messages from us about HIV. She will " +
                         "get her regular MomConnect messages. For any medical concerns, please visit a clinic."
                 })
@@ -709,6 +734,9 @@ describe("ussd_pmtct app", function() {
                                 optout_reason: "babyloss",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             }
                         )
                     );
@@ -716,7 +744,7 @@ describe("ussd_pmtct app", function() {
                 .input({session_event: "continue"})
                 .check.interaction({
                     state: "state_loss_subscription",
-                    reply: 
+                    reply:
                     "Thank you. She will receive messages of support from MomConnect in the coming weeks."
                 })
                 .check.reply.ends_session()
@@ -745,6 +773,9 @@ describe("ussd_pmtct app", function() {
                                 optout_reason: "babyloss",
                                 dob:  "1990-01-01T00:00:00Z",
                                 source: "PMTCT USSD",
+                                registered_by: "+27123456789",
+                                mha: 1,
+                                swt: 1,
                             },
                             true
                         )


### PR DESCRIPTION
We need to start the flow on the msisdn entered if it was entered.
We need to send registered_by, mha and swt when starting the flow.