### PR TITLE
Change welcome, remove language, and disable SMS registration

### DIFF
--- a/go-app-ussd_chw_rapidpro.js
+++ b/go-app-ussd_chw_rapidpro.js
@@ -204,9 +204,9 @@ go.app = function() {
             self.im.user.answers = {};
             return new MenuState(name, {
                 question: $([
-                    "Welcome to the Department of Health's MomConnect (MC).",
+                    "Welcome to the Department of Health's MomConnect. We only send WhatsApp msgs in English.",
                     "",
-                    "Is {{msisdn}} the cell number of the mother who wants to sign up?"
+                    "Is {{msisdn}} the no. signing up?",
                     ].join("\n")).context({msisdn: utils.readable_msisdn(self.im.user.addr, "27")}),
                 error: $(
                     "Sorry we don't understand. Please enter the number next to the mother's " +
@@ -513,7 +513,7 @@ go.app = function() {
                     }
 
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -553,7 +553,7 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -631,36 +631,6 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
-            });
-        });
-
-        self.add("state_language", function(name) {
-            return new PaginatedChoiceState(name, {
-                question: $(
-                    "What language does the mother want to receive her MomConnect messages in?"
-                ),
-                error: $(
-                    "Sorry we don't understand. Please enter the number next to the mother's " +
-                    "answer."
-                ),
-                choices: [
-                    new Choice("zul", $("isiZulu")),
-                    new Choice("xho", $("isiXhosa")),
-                    new Choice("afr", $("Afrikaans")),
-                    new Choice("eng", $("English")),
-                    new Choice("nso", $("Sesotho sa Leboa")),
-                    new Choice("tsn", $("Setswana")),
-                    new Choice("sot", $("Sesotho")),
-                    new Choice("tso", $("Xitsonga")),
-                    new Choice("ssw", $("siSwati")),
-                    new Choice("ven", $("Tshivenda")),
-                    new Choice("nbl", $("isiNdebele"))
-                ],
-                back: $("Back"),
-                more: $("Next"),
-                options_per_page: null,
-                characters_per_page: 160,
                 next: "state_whatsapp_contact_check"
             });
         });
@@ -684,13 +654,16 @@ go.app = function() {
         });
 
         self.add("state_trigger_rapidpro_flow", function(name, opts) {
+            if(!self.im.user.answers.on_whatsapp) {
+                return self.states.create("state_not_on_whatsapp");
+            }
             var msisdn = utils.normalize_msisdn(
                 _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr), "ZA");
             var data = {
                 research_consent:
                     self.im.user.answers.state_research_consent === "no" ? "FALSE" : "TRUE",
                 registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
-                language: self.im.user.answers.state_language,
+                language: "eng",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
                 source: "CHW USSD",
                 id_type: {
@@ -712,7 +685,7 @@ go.app = function() {
                     ).format(),
                 passport_origin: self.im.user.answers.state_passport_country,
                 passport_number: self.im.user.answers.state_passport_no,
-                swt: self.im.user.answers.on_whatsapp ? "7" : "1"
+                swt: "7"
             };
             return self.rapidpro
                 .start_flow(self.im.config.flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"), data)
@@ -735,14 +708,19 @@ go.app = function() {
                 "You're done! {{ msisdn }} will get helpful messages from MomConnect on WhatsApp. " +
                 "To sign up for the full set of messages, visit a clinic. " +
                 "Have a lovely day!").context({msisdn: msisdn});
-            var sms_message = $(
-                "You're done! {{ msisdn }} will get helpful messages from MomConnect on SMS. " +
-                "You can register for the full set of FREE messages at a clinic. " +
-                "Have a lovely day!").context({msisdn: msisdn});
-
             return new EndState(name, {
                 next: "state_start",
-                text: self.im.user.get_answer("on_whatsapp") ? whatsapp_message : sms_message
+                text: whatsapp_message
+            });
+        });
+
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                next: "state_start",
+                text: $(
+                    "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                    "You can dial *134*550*2# again on a cell number that has WhatsApp."
+                )
             });
         });
 

--- a/go-app-ussd_clinic_rapidpro.js
+++ b/go-app-ussd_clinic_rapidpro.js
@@ -340,9 +340,9 @@ go.app = function() {
             self.im.user.answers = {};
             return new MenuState(name, {
                 question: $([
-                    "Welcome to the Department of Health's MomConnect (MC).",
+                    "Welcome to the Department of Health's MomConnect. We only send WhatsApp msgs in English.",
                     "",
-                    "Is {{msisdn}} the cell number of the mother who wants to sign up?"
+                    "Is {{msisdn}} the no. signing up?",
                     ].join("\n")).context({msisdn: utils.readable_msisdn(self.im.user.addr, "27")}),
                 error: $(
                     "Sorry we don't understand. Please enter the number next to the mother's " +
@@ -876,7 +876,7 @@ go.app = function() {
                     }
 
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -916,7 +916,7 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -994,36 +994,6 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
-            });
-        });
-
-        self.add("state_language", function(name) {
-            return new PaginatedChoiceState(name, {
-                question: $(
-                    "What language does the mother want to receive her MomConnect messages in?"
-                ),
-                error: $(
-                    "Sorry we don't understand. Please enter the number next to the mother's " +
-                    "answer."
-                ),
-                choices: [
-                    new Choice("zul", $("isiZulu")),
-                    new Choice("xho", $("isiXhosa")),
-                    new Choice("afr", $("Afrikaans")),
-                    new Choice("eng", $("English")),
-                    new Choice("nso", $("Sesotho sa Leboa")),
-                    new Choice("tsn", $("Setswana")),
-                    new Choice("sot", $("Sesotho")),
-                    new Choice("tso", $("Xitsonga")),
-                    new Choice("ssw", $("siSwati")),
-                    new Choice("ven", $("Tshivenda")),
-                    new Choice("nbl", $("isiNdebele"))
-                ],
-                back: $("Back"),
-                more: $("Next"),
-                options_per_page: null,
-                characters_per_page: 160,
                 next: "state_whatsapp_contact_check"
             });
         });
@@ -1047,13 +1017,16 @@ go.app = function() {
         });
 
         self.add("state_trigger_rapidpro_flow", function(name, opts) {
+            if(!self.im.user.answers.on_whatsapp) {
+                return self.states.create("state_not_on_whatsapp");
+            }
             var msisdn = utils.normalize_msisdn(
                 _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr), "ZA");
             var data = {
                 research_consent:
                     self.im.user.answers.state_research_consent === "no" ? "FALSE" : "TRUE",
                 registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
-                language: self.im.user.answers.state_language,
+                language: "eng",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
                 source: "Clinic USSD",
                 id_type: {
@@ -1076,7 +1049,7 @@ go.app = function() {
                     ).format(),
                 passport_origin: self.im.user.answers.state_passport_country,
                 passport_number: self.im.user.answers.state_passport_no,
-                swt: self.im.user.answers.on_whatsapp ? "7" : "1"
+                swt: "7"
             };
             var flow_uuid;
             if(self.im.user.answers.state_message_type === "state_edd_month") {
@@ -1114,12 +1087,21 @@ go.app = function() {
         self.states.add("state_registration_complete", function(name) {
             var msisdn = _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr);
             msisdn = utils.readable_msisdn(msisdn, "27");
-            var channel = self.im.user.answers.on_whatsapp ? $("WhatsApp") : $("SMS");
             return new EndState(name, {
                 text: $(
                     "You're done! This number {{msisdn}} will get helpful messages from " +
                     "MomConnect on {{channel}}. Thanks for signing up to MomConnect!"
-                ).context({msisdn: msisdn, channel: channel}),
+                ).context({msisdn: msisdn, channel: $("WhatsApp")}),
+                next: "state_start"
+            });
+        });
+
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                text: $(
+                    "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                    "You can dial *134*550*2# again on a cell number that has WhatsApp."
+                ),
                 next: "state_start"
             });
         });

--- a/go-app-ussd_pmtct_rapidpro.js
+++ b/go-app-ussd_pmtct_rapidpro.js
@@ -152,8 +152,8 @@ go.app = function() {
             self.im.user.answers = {};
             return new MenuState(name, {
                 question: $([
-                    "Welcome to the Dept. of Health's MomConnect (MC). Is {{msisdn}} " +
-                    "the no. of the mom who wants to sign up/opt out of HIV msgs?"
+                    "Welcome! The Dept. of Health’s MomConnect sends Eng msgs on WhatsApp.",
+                    "Is {{msisdn}} the no. signing up/opting out of HIV msgs?"
                     ].join("\n")).context({msisdn: utils.readable_msisdn(self.im.user.addr, "27")}),
                 error:
                     "Sorry we don't understand. Please enter the number next to the mother's " +

--- a/go-app-ussd_public_rapidpro.js
+++ b/go-app-ussd_public_rapidpro.js
@@ -211,10 +211,6 @@ go.app = function() {
             return self.rapidpro.get_contact({urn: "whatsapp:" + _.trim(msisdn, "+")})
                 .then(function(contact) {
                     self.im.user.set_answer("contact", contact);
-                    // Set the language if we have it
-                    if(_.isString(_.get(contact, "language"))) {
-                        return self.im.user.set_lang(contact.language);
-                    }
                 }).then(function() {
                     // Delegate to the correct state depending on contact fields
                     var contact = self.im.user.get_answer("contact");
@@ -422,16 +418,19 @@ go.app = function() {
         });
 
         self.add("state_trigger_rapidpro_flow", function(name, opts) {
+            if (!self.im.user.get_answer("on_whatsapp")) {
+                return self.states.create("state_not_on_whatsapp");
+            }
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             var data = {
-                on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "TRUE" : "FALSE",
+                on_whatsapp: "TRUE",
                 research_consent: self.im.user.get_answer("state_research_consent") === "yes" ? "TRUE" : "FALSE",
-                language: self.im.user.lang,
+                language: "eng",
                 source: "Public USSD",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
-                registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
+                registered_by: msisdn,
                 mha: 6,
-                swt: self.im.user.get_answer("on_whatsapp") ? 7 : 1
+                swt: 7
             };
             return self.rapidpro
                 .start_flow(self.im.config.flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"), data)
@@ -448,17 +447,24 @@ go.app = function() {
                 });
         });
 
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                next: "state_start",
+                text: $(
+                    "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                    "You can dial *134*550*2# again on a cell number that has WhatsApp."
+                )
+            });
+        });
+
         self.states.add("state_registration_complete", function(name) {
             var msisdn = utils.readable_msisdn(utils.normalize_msisdn(self.im.user.addr, "ZA"), "27");
             var whatsapp_message = $(
                 "You're done! This number {{ msisdn }} will get helpful messages from MomConnect on WhatsApp. For " +
                 "the full set of messages, visit a clinic.").context({msisdn: msisdn});
-            var sms_message = $(
-                "You're done! This number {{ msisdn }} will get helpful messages from MomConnect on SMS. You can " +
-                "register for the full set of FREE messages at a clinic.").context({msisdn: msisdn});
             return new EndState(name, {
                 next: "state_start",
-                text: self.im.user.get_answer("on_whatsapp") ? whatsapp_message : sms_message
+                text: whatsapp_message,
             });
         });
 

--- a/go-app-ussd_public_rapidpro.js
+++ b/go-app-ussd_public_rapidpro.js
@@ -223,7 +223,7 @@ go.app = function() {
                     } else if(_.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7)) {
                         return self.states.create("state_clinic_subscription");
                     } else {
-                        return self.states.create("state_language");
+                        return self.states.create("state_pregnant");
                     }
                 }).catch(function(e) {
                     // Go to error state after 3 failed HTTP requests
@@ -256,69 +256,19 @@ go.app = function() {
             });
         });
 
-        self.states.add("state_language", function(name) {
-            // Skip this state if we already have a language
-            var language = _.get(self.im.user.get_answer("contact"), "language");
-            if(_.isString(language)) {
-                return self.states.create("state_pregnant");
-            }
-            // No translations are needed for this state, since we don't know the language yet
-            var question = "Welcome to the Department of Health's MomConnect (MC). Please select your language:";
-            // TODO: use the error pretext. There is currently a bug in the sandbox that doesn't take into account
-            // the length of the error message when calculating choices
-            // var error_pretext = "Sorry, please reply with the number next to your answer.";
-            return new PaginatedChoiceState(name, {
-                question: question,
-                error: question,
-                accept_labels: true,
-                options_per_page: null,
-                characters_per_page: 160,
-                choices: [
-                    new Choice('zul', 'isiZulu'),
-                    new Choice('xho', 'isiXhosa'),
-                    new Choice('afr', 'Afrikaans'),
-                    new Choice('eng', 'English'),
-                    new Choice('nso', 'Sesotho sa Leboa'),
-                    new Choice('tsn', 'Setswana'),
-                    new Choice('sot', 'Sesotho'),
-                    new Choice('tso', 'Xitsonga'),
-                    new Choice('ssw', 'siSwati'),
-                    new Choice('ven', 'Tshivenda'),
-                    new Choice('nbl', 'isiNdebele')
-                ],
-                next: function(choice) {
-                    return self.im.user
-                        .set_lang(choice.value)
-                        .then(_.constant("state_pregnant"));
-                }
-            });
-        });
-
-        self.add("state_pregnant", function(name) {
+        self.states.add("state_pregnant", function(name) {
             return new MenuState(name, {
                 question: $(
-                    "MomConnect sends free messages to help pregnant moms and babies. Are you or do you suspect that you " +
-                    "are pregnant?"
+                    "Welcome to the Department of Health’s MomConnect. We only send WhatsApp msgs in English."
                 ),
                 error: $(
-                    "Sorry, please reply with the number next to your answer. Are you or do you suspect that you are " +
-                    "pregnant?"
+                    "Sorry, please reply with the number next to your answer. " +
+                    "We only send WhatsApp msgs in English."
                 ),
                 accept_labels: true,
                 choices: [
-                    new Choice("state_info_consent", $("Yes")),
-                    new Choice("state_pregnant_only", $("No"))
+                    new Choice("state_info_consent", $("Continue")),
                 ]
-            });
-        });
-
-        self.states.add("state_pregnant_only", function(name) {
-            return new EndState(name, {
-                next: "state_start",
-                text: $(
-                    "We're sorry but this service is only for pregnant mothers. If you have other health concerns " +
-                    "please visit your nearest clinic. Have a lovely day!"
-                )
             });
         });
 

--- a/src/ussd_chw_rapidpro.js
+++ b/src/ussd_chw_rapidpro.js
@@ -55,9 +55,9 @@ go.app = function() {
             self.im.user.answers = {};
             return new MenuState(name, {
                 question: $([
-                    "Welcome to the Department of Health's MomConnect (MC).",
+                    "Welcome to the Department of Health's MomConnect. We only send WhatsApp msgs in English.",
                     "",
-                    "Is {{msisdn}} the cell number of the mother who wants to sign up?"
+                    "Is {{msisdn}} the no. signing up?",
                     ].join("\n")).context({msisdn: utils.readable_msisdn(self.im.user.addr, "27")}),
                 error: $(
                     "Sorry we don't understand. Please enter the number next to the mother's " +
@@ -364,7 +364,7 @@ go.app = function() {
                     }
 
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -404,7 +404,7 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
+                next: "state_whatsapp_contact_check"
             });
         });
 
@@ -482,36 +482,6 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_language"
-            });
-        });
-
-        self.add("state_language", function(name) {
-            return new PaginatedChoiceState(name, {
-                question: $(
-                    "What language does the mother want to receive her MomConnect messages in?"
-                ),
-                error: $(
-                    "Sorry we don't understand. Please enter the number next to the mother's " +
-                    "answer."
-                ),
-                choices: [
-                    new Choice("zul", $("isiZulu")),
-                    new Choice("xho", $("isiXhosa")),
-                    new Choice("afr", $("Afrikaans")),
-                    new Choice("eng", $("English")),
-                    new Choice("nso", $("Sesotho sa Leboa")),
-                    new Choice("tsn", $("Setswana")),
-                    new Choice("sot", $("Sesotho")),
-                    new Choice("tso", $("Xitsonga")),
-                    new Choice("ssw", $("siSwati")),
-                    new Choice("ven", $("Tshivenda")),
-                    new Choice("nbl", $("isiNdebele"))
-                ],
-                back: $("Back"),
-                more: $("Next"),
-                options_per_page: null,
-                characters_per_page: 160,
                 next: "state_whatsapp_contact_check"
             });
         });
@@ -535,13 +505,16 @@ go.app = function() {
         });
 
         self.add("state_trigger_rapidpro_flow", function(name, opts) {
+            if(!self.im.user.answers.on_whatsapp) {
+                return self.states.create("state_not_on_whatsapp");
+            }
             var msisdn = utils.normalize_msisdn(
                 _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr), "ZA");
             var data = {
                 research_consent:
                     self.im.user.answers.state_research_consent === "no" ? "FALSE" : "TRUE",
                 registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
-                language: self.im.user.answers.state_language,
+                language: "eng",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
                 source: "CHW USSD",
                 id_type: {
@@ -563,7 +536,7 @@ go.app = function() {
                     ).format(),
                 passport_origin: self.im.user.answers.state_passport_country,
                 passport_number: self.im.user.answers.state_passport_no,
-                swt: self.im.user.answers.on_whatsapp ? "7" : "1"
+                swt: "7"
             };
             return self.rapidpro
                 .start_flow(self.im.config.flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"), data)
@@ -586,14 +559,19 @@ go.app = function() {
                 "You're done! {{ msisdn }} will get helpful messages from MomConnect on WhatsApp. " +
                 "To sign up for the full set of messages, visit a clinic. " +
                 "Have a lovely day!").context({msisdn: msisdn});
-            var sms_message = $(
-                "You're done! {{ msisdn }} will get helpful messages from MomConnect on SMS. " +
-                "You can register for the full set of FREE messages at a clinic. " +
-                "Have a lovely day!").context({msisdn: msisdn});
-
             return new EndState(name, {
                 next: "state_start",
-                text: self.im.user.get_answer("on_whatsapp") ? whatsapp_message : sms_message
+                text: whatsapp_message
+            });
+        });
+
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                next: "state_start",
+                text: $(
+                    "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                    "You can dial *134*550*2# again on a cell number that has WhatsApp."
+                )
             });
         });
 

--- a/src/ussd_pmtct_rapidpro.js
+++ b/src/ussd_pmtct_rapidpro.js
@@ -49,8 +49,8 @@ go.app = function() {
             self.im.user.answers = {};
             return new MenuState(name, {
                 question: $([
-                    "Welcome to the Dept. of Health's MomConnect (MC). Is {{msisdn}} " +
-                    "the no. of the mom who wants to sign up/opt out of HIV msgs?"
+                    "Welcome! The Dept. of Health’s MomConnect sends Eng msgs on WhatsApp.",
+                    "Is {{msisdn}} the no. signing up/opting out of HIV msgs?"
                     ].join("\n")).context({msisdn: utils.readable_msisdn(self.im.user.addr, "27")}),
                 error:
                     "Sorry we don't understand. Please enter the number next to the mother's " +

--- a/src/ussd_public_rapidpro.js
+++ b/src/ussd_public_rapidpro.js
@@ -74,7 +74,7 @@ go.app = function() {
                     } else if(_.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7)) {
                         return self.states.create("state_clinic_subscription");
                     } else {
-                        return self.states.create("state_language");
+                        return self.states.create("state_pregnant");
                     }
                 }).catch(function(e) {
                     // Go to error state after 3 failed HTTP requests
@@ -107,69 +107,19 @@ go.app = function() {
             });
         });
 
-        self.states.add("state_language", function(name) {
-            // Skip this state if we already have a language
-            var language = _.get(self.im.user.get_answer("contact"), "language");
-            if(_.isString(language)) {
-                return self.states.create("state_pregnant");
-            }
-            // No translations are needed for this state, since we don't know the language yet
-            var question = "Welcome to the Department of Health's MomConnect (MC). Please select your language:";
-            // TODO: use the error pretext. There is currently a bug in the sandbox that doesn't take into account
-            // the length of the error message when calculating choices
-            // var error_pretext = "Sorry, please reply with the number next to your answer.";
-            return new PaginatedChoiceState(name, {
-                question: question,
-                error: question,
-                accept_labels: true,
-                options_per_page: null,
-                characters_per_page: 160,
-                choices: [
-                    new Choice('zul', 'isiZulu'),
-                    new Choice('xho', 'isiXhosa'),
-                    new Choice('afr', 'Afrikaans'),
-                    new Choice('eng', 'English'),
-                    new Choice('nso', 'Sesotho sa Leboa'),
-                    new Choice('tsn', 'Setswana'),
-                    new Choice('sot', 'Sesotho'),
-                    new Choice('tso', 'Xitsonga'),
-                    new Choice('ssw', 'siSwati'),
-                    new Choice('ven', 'Tshivenda'),
-                    new Choice('nbl', 'isiNdebele')
-                ],
-                next: function(choice) {
-                    return self.im.user
-                        .set_lang(choice.value)
-                        .then(_.constant("state_pregnant"));
-                }
-            });
-        });
-
-        self.add("state_pregnant", function(name) {
+        self.states.add("state_pregnant", function(name) {
             return new MenuState(name, {
                 question: $(
-                    "MomConnect sends free messages to help pregnant moms and babies. Are you or do you suspect that you " +
-                    "are pregnant?"
+                    "Welcome to the Department of Health’s MomConnect. We only send WhatsApp msgs in English."
                 ),
                 error: $(
-                    "Sorry, please reply with the number next to your answer. Are you or do you suspect that you are " +
-                    "pregnant?"
+                    "Sorry, please reply with the number next to your answer. " +
+                    "We only send WhatsApp msgs in English."
                 ),
                 accept_labels: true,
                 choices: [
-                    new Choice("state_info_consent", $("Yes")),
-                    new Choice("state_pregnant_only", $("No"))
+                    new Choice("state_info_consent", $("Continue")),
                 ]
-            });
-        });
-
-        self.states.add("state_pregnant_only", function(name) {
-            return new EndState(name, {
-                next: "state_start",
-                text: $(
-                    "We're sorry but this service is only for pregnant mothers. If you have other health concerns " +
-                    "please visit your nearest clinic. Have a lovely day!"
-                )
             });
         });
 

--- a/test/ussd_chw_rapidpro.test.js
+++ b/test/ussd_chw_rapidpro.test.js
@@ -33,9 +33,9 @@ describe("ussd_chw app", function() {
                 .check.interaction({
                     state: 'state_start',
                     reply: [
-                    "Welcome to the Department of Health's MomConnect (MC).",
+                    "Welcome to the Department of Health's MomConnect. We only send WhatsApp msgs in English.",
                     "",
-                    "Is 0123456789 the cell number of the mother who wants to sign up?",
+                    "Is 0123456789 the no. signing up?",
                     "1. Yes",
                     "2. No"
                 ].join("\n"),
@@ -533,13 +533,6 @@ describe("ussd_chw app", function() {
                 })
                 .run();
         });
-        it("should go to state_language if the ID number is valid", function() {
-            return tester
-                .setup.user.state("state_sa_id_no")
-                .input("9001020005087")
-                .check.user.state("state_language")
-                .run();
-        });
     });
     describe("state_passport_country", function() {
         it("should ask the user which country the passport is for", function() {
@@ -606,13 +599,6 @@ describe("ussd_chw app", function() {
                         "Sorry, we don't understand. Please try again by entering the mother's " +
                         "Passport number as it appears in her passport."
                 })
-                .run();
-        });
-        it("should go to state_language on a successful input", function() {
-            return tester
-                .setup.user.state("state_passport_no")
-                .input("A1234567890")
-                .check.user.state("state_language")
                 .run();
         });
     });
@@ -723,68 +709,6 @@ describe("ussd_chw app", function() {
                 })
                 .run();
         });
-        it("should go to state_language on a valid input", function() {
-            return tester
-                .setup.user.state("state_dob_day")
-                .setup.user.answers({state_dob_year: "1987", state_dob_month: "02"})
-                .input("22")
-                .check.user.state("state_language")
-                .run();
-        });
-    });
-    describe("state_language", function() {
-        it("should ask the user for the language", function() {
-            return tester
-                .setup.user.state("state_language")
-                .check.interaction({
-                    reply: [
-                        "What language does the mother want to receive her MomConnect messages in?",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. Next"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should be able to page through choices", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("6")
-                .check.interaction({
-                    reply: [
-                        "What language does the mother want to receive her MomConnect messages in?",
-                        "1. Setswana",
-                        "2. Sesotho",
-                        "3. Xitsonga",
-                        "4. siSwati",
-                        "5. Tshivenda",
-                        "6. isiNdebele",
-                        "7. Back"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should display an error for an incorrect choice", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("A")
-                .check.interaction({
-                    reply: [
-                        "Sorry we don't understand. Please enter the number next to the " +
-                        "mother's answer.",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. Next"
-                    ].join("\n")
-                })
-                .run();
-        });
     });
     describe("state_whatsapp_contact_check", function() {
         it("should store the result of the contact check", function() {
@@ -831,7 +755,6 @@ describe("ussd_chw app", function() {
                 .setup.user.answers({
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087",
                     on_whatsapp: "FALSE"
@@ -851,7 +774,7 @@ describe("ussd_chw app", function() {
                             {
                                 research_consent:"FALSE",
                                 registered_by: "+27123456789",
-                                language: "zul",
+                                language: "eng",
                                 timestamp: "2014-04-04T07:07:07Z",
                                 source: "CHW USSD",
                                 id_type: "sa_id",
@@ -873,13 +796,12 @@ describe("ussd_chw app", function() {
                 .check.reply.ends_session()
                 .run();
         });
-        it("should go to state_registration_complete for SMS registration", function() {
+        it("should go to state_not_on_whatsapp for SMS registration", function() {
             return tester
                 .setup.user.state("state_trigger_rapidpro_flow")
                 .setup.user.answers({
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087"
                 })
@@ -890,32 +812,13 @@ describe("ussd_chw app", function() {
                             wait: true
                         })
                     );
-                    api.http.fixtures.add(
-                        fixtures_rapidpro.start_flow(
-                            "rapidpro-flow-uuid",
-                            null,
-                            "whatsapp:27820001001",
-                            {
-                                research_consent:"FALSE",
-                                registered_by: "+27123456789",
-                                language: "zul",
-                                timestamp: "2014-04-04T07:07:07Z",
-                                source: "CHW USSD",
-                                id_type: "sa_id",
-                                sa_id_number: "9001020005087",
-                                dob: "1990-01-02T00:00:00Z",
-                                swt: "1",
-                            }
-                        )
-                    );
                 })
                 .input({session_event: "continue"})
                 .check.interaction({
-                    state: "state_registration_complete",
+                    state: "state_not_on_whatsapp",
                     reply: 
-                        "You're done! 0123456789 will get helpful messages from " +
-                        "MomConnect on SMS. You can register for the full set of " +
-                        "FREE messages at a clinic. Have a lovely day!"
+                        "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                        "You can dial *134*550*2# again on a cell number that has WhatsApp."
                 })
                 .check.reply.ends_session()
                 .run();
@@ -926,29 +829,23 @@ describe("ussd_chw app", function() {
                 .setup.user.answers({
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087",
+                    on_whatsapp: true,
                 })
                 .setup(function(api) {
-                    api.http.fixtures.add(
-                        fixtures_whatsapp.exists({
-                            address: "+27820001001",
-                            wait: true,
-                        })
-                    );
                     api.http.fixtures.add(
                         fixtures_rapidpro.start_flow(
                             "rapidpro-flow-uuid", null, "whatsapp:27820001001", {
                                 research_consent:"FALSE",
                                 registered_by: "+27123456789",
-                                language: "zul",
+                                language: "eng",
                                 timestamp: "2014-04-04T07:07:07Z",
                                 source: "CHW USSD",
                                 id_type: "sa_id",
                                 sa_id_number: "9001020005087",
                                 dob: "1990-01-02T00:00:00Z",
-                                swt: "1"
+                                swt: "7"
                             }, true
                         )
                     );

--- a/test/ussd_clinic_rapidpro.test.js
+++ b/test/ussd_clinic_rapidpro.test.js
@@ -47,9 +47,9 @@ describe("ussd_clinic app", function() {
                 .check.interaction({
                     state: "state_start",
                     reply: [
-                        "Welcome to the Department of Health's MomConnect (MC).",
+                        "Welcome to the Department of Health's MomConnect. We only send WhatsApp msgs in English.",
                         "",
-                        "Is 0123456789 the cell number of the mother who wants to sign up?",
+                        "Is 0123456789 the no. signing up?",
                         "1. Yes",
                         "2. No"
                     ].join("\n"),
@@ -1215,17 +1215,6 @@ describe("ussd_clinic app", function() {
                 })
                 .run();
         });
-        it("should go to state_language if the ID number is valid", function() {
-            return tester
-                .setup.user.state("state_sa_id_no")
-                .input("9001020005087")
-                .check.user.state("state_language")
-                .check(function(api) {
-                    var metrics = api.metrics.stores.test_metric_store;
-                    assert.deepEqual(metrics['enter.state_language'], {agg: 'sum', values: [1]});
-                })
-                .run();
-        });
     });
     describe("state_passport_country", function() {
         it("should ask the user which country the passport is for", function() {
@@ -1295,17 +1284,6 @@ describe("ussd_clinic app", function() {
                     reply: 
                         "Sorry, we don't understand. Please try again by entering the mother's " +
                         "Passport number as it appears in her passport."
-                })
-                .run();
-        });
-        it("should go to state_language on a successful input", function() {
-            return tester
-                .setup.user.state("state_passport_no")
-                .input("A1234567890")
-                .check.user.state("state_language")
-                .check(function(api) {
-                    var metrics = api.metrics.stores.test_metric_store;
-                    assert.deepEqual(metrics['enter.state_language'], {agg: 'sum', values: [1]});
                 })
                 .run();
         });
@@ -1425,72 +1403,6 @@ describe("ussd_clinic app", function() {
                 })
                 .run();
         });
-        it("should go to state_language on a valid input", function() {
-            return tester
-                .setup.user.state("state_dob_day")
-                .setup.user.answers({state_dob_year: "1987", state_dob_month: "02"})
-                .input("22")
-                .check.user.state("state_language")
-                .check(function(api) {
-                    var metrics = api.metrics.stores.test_metric_store;
-                    assert.deepEqual(metrics['enter.state_language'], {agg: 'sum', values: [1]});
-                })
-                .run();
-        });
-    });
-    describe("state_language", function() {
-        it("should ask the user for the language", function() {
-            return tester
-                .setup.user.state("state_language")
-                .check.interaction({
-                    reply: [
-                        "What language does the mother want to receive her MomConnect messages in?",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. Next"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should be able to page through choices", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("6")
-                .check.interaction({
-                    reply: [
-                        "What language does the mother want to receive her MomConnect messages in?",
-                        "1. Setswana",
-                        "2. Sesotho",
-                        "3. Xitsonga",
-                        "4. siSwati",
-                        "5. Tshivenda",
-                        "6. isiNdebele",
-                        "7. Back"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should display an error for an incorrect choice", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("A")
-                .check.interaction({
-                    reply: [
-                        "Sorry we don't understand. Please enter the number next to the " +
-                        "mother's answer.",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. Next"
-                    ].join("\n")
-                })
-                .run();
-        });
     });
     describe("state_whatsapp_contact_check + state_trigger_rapidpro_flow", function() {
         it("should make a request to the WhatsApp and RapidPro APIs for prebirth", function() {
@@ -1500,7 +1412,6 @@ describe("ussd_clinic app", function() {
                     state_message_type: "state_edd_month",
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087",
                     state_edd_month: "201502",
@@ -1519,7 +1430,7 @@ describe("ussd_clinic app", function() {
                             "prebirth-flow-uuid", null, "whatsapp:27820001001", {
                                 research_consent: "FALSE",
                                 registered_by: "+27123456789",
-                                language: "zul",
+                                language: "eng",
                                 timestamp: "2014-04-04T07:07:07Z",
                                 source: "Clinic USSD",
                                 id_type: "sa_id",
@@ -1557,7 +1468,6 @@ describe("ussd_clinic app", function() {
                     state_message_type: "state_birth_year",
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087",
                     state_birth_month: "2014-02",
@@ -1576,7 +1486,7 @@ describe("ussd_clinic app", function() {
                             "postbirth-flow-uuid", null, "whatsapp:27820001001", {
                                 research_consent: "FALSE",
                                 registered_by: "+27123456789",
-                                language: "zul",
+                                language: "eng",
                                 timestamp: "2014-04-04T07:07:07Z",
                                 source: "Clinic USSD",
                                 id_type: "sa_id",
@@ -1643,7 +1553,6 @@ describe("ussd_clinic app", function() {
                     state_message_type: "state_edd_month",
                     state_research_consent: "no",
                     state_enter_msisdn: "0820001001",
-                    state_language: "zul",
                     state_id_type: "state_sa_id_no",
                     state_sa_id_no: "9001020005087",
                     state_edd_month: "201502",
@@ -1662,7 +1571,7 @@ describe("ussd_clinic app", function() {
                             "prebirth-flow-uuid", null, "whatsapp:27820001001", {
                                 research_consent: "FALSE",
                                 registered_by: "+27123456789",
-                                language: "zul",
+                                language: "eng",
                                 timestamp: "2014-04-04T07:07:07Z",
                                 source: "Clinic USSD",
                                 id_type: "sa_id",

--- a/test/ussd_pmtct_rapidpro.test.js
+++ b/test/ussd_pmtct_rapidpro.test.js
@@ -29,8 +29,8 @@ describe("ussd_pmtct app", function() {
                 .check.interaction({
                     state: 'state_start',
                     reply: [
-                    "Welcome to the Dept. of Health's MomConnect (MC). Is 0123456789 the " +
-                    "no. of the mom who wants to sign up/opt out of HIV msgs?",
+                    "Welcome! The Dept. of Health’s MomConnect sends Eng msgs on WhatsApp.",
+                    "Is 0123456789 the no. signing up/opting out of HIV msgs?",
                     "1. Yes",
                     "2. No"
                 ].join("\n"),

--- a/test/ussd_public_rapidpro.test.js
+++ b/test/ussd_public_rapidpro.test.js
@@ -95,7 +95,7 @@ describe("ussd_public app", function() {
                 .check.user.lang("zul")
                 .run();
         });
-        it("should ask the user for their language if they don't have a subscription", function() {
+        it("should welcome the user if they don't have a subscription", function() {
             return tester
                 .setup(function(api) {
                     api.http.fixtures.add(
@@ -106,10 +106,10 @@ describe("ussd_public app", function() {
                     );
                 })
                 .start()
-                .check.user.state("state_language")
+                .check.user.state("state_pregnant")
                 .run();
         });
-        it("should ask the user for their language if they don't have a contact", function() {
+        it("should welcome the user if they don't have a contact", function() {
             return tester
                 .setup(function(api) {
                     api.http.fixtures.add(
@@ -120,61 +120,6 @@ describe("ussd_public app", function() {
                     );
                 })
                 .start()
-                .check.user.state("state_language")
-                .run();
-        });
-    });
-    describe("state_language", function() {
-        it("should display the list of languages", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input({session_event: "continue"})
-                .check.interaction({
-                    state: "state_language",
-                    reply: [
-                        "Welcome to the Department of Health's MomConnect (MC). Please select your language:",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. More"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should set the language if a language is selected", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("5")
-                .check.user.lang("nso")
-                .check.user.answer("state_language", "nso")
-                .check.user.state("state_pregnant")
-                .run();
-        });
-        it("should display an error if an incorrect input is sent", function() {
-            return tester
-                .setup.user.state("state_language")
-                .input("foo")
-                .check.interaction({
-                    state: "state_language",
-                    reply: [
-                        "Welcome to the Department of Health's MomConnect (MC). Please select your language:",
-                        "1. isiZulu",
-                        "2. isiXhosa",
-                        "3. Afrikaans",
-                        "4. English",
-                        "5. Sesotho sa Leboa",
-                        "6. More"
-                    ].join("\n"),
-                })
-                .run();
-        });
-        it("should skip asking for language if the user has previously selected a language", function() {
-            return tester
-                .setup.user.state("state_language")
-                .setup.user.answer("contact", {"language": "zul"})
-                .input({session_event: "continue"})
                 .check.user.state("state_pregnant")
                 .run();
         });
@@ -187,11 +132,10 @@ describe("ussd_public app", function() {
                 .check.interaction({
                     state: "state_pregnant",
                     reply: [
-                        "MomConnect sends free messages to help pregnant moms and babies. Are you or do you suspect that you " +
-                        "are pregnant?",
-                        "1. Yes",
-                        "2. No"
-                    ].join("\n")
+                        "Welcome to the Department of Health’s MomConnect. We only send WhatsApp msgs in English.",
+                        "1. Continue",
+                    ].join("\n"),
+                    char_limit: 140,
                 })
                 .run();
         });
@@ -202,27 +146,15 @@ describe("ussd_public app", function() {
                 .check.interaction({
                     state: "state_pregnant",
                     reply: [
-                        "Sorry, please reply with the number next to your answer. Are you or do you suspect that " +
-                        "you are pregnant?",
-                        "1. Yes",
-                        "2. No"
-                    ].join("\n")
+                        "Sorry, please reply with the number next to your answer. " +
+                        "We only send WhatsApp msgs in English.",
+                        "1. Continue",
+                    ].join("\n"),
+                    char_limit: 140,
                 })
                 .run();
         });
-        it("should turn the user away if they aren't pregnant", function() {
-            return tester
-                .setup.user.state("state_pregnant")
-                .input("2")
-                .check.interaction({
-                    state: "state_pregnant_only",
-                    reply:
-                        "We're sorry but this service is only for pregnant mothers. If you have other health concerns " +
-                        "please visit your nearest clinic. Have a lovely day!"
-                })
-                .run();
-        });
-        it("should ask them for consent if they are pregnant", function() {
+        it("should ask them for consent if they continue", function() {
             return tester
                 .setup.user.state("state_pregnant")
                 .input("1")
@@ -464,7 +396,7 @@ describe("ussd_public app", function() {
     describe("timeout testing", function() {
         it("should go to state_timed_out", function() {
             return tester
-                .setup.user.state("state_pregnant")
+                .setup.user.state("state_info_consent")
                 .inputs(
                     {session_event: "close"}
                     , {session_event: "new"}

--- a/test/ussd_public_rapidpro.test.js
+++ b/test/ussd_public_rapidpro.test.js
@@ -80,7 +80,6 @@ describe("ussd_public app", function() {
                         fixtures_rapidpro.get_contact({
                             urn: "whatsapp:27123456789",
                             exists: true,
-                            language: "zul",
                             fields: {prebirth_messaging: "3"}
                         })
                     );
@@ -92,7 +91,6 @@ describe("ussd_public app", function() {
                         "Hello mom! You can reply to any MomConnect message with a question, compliment or complaint. Our team " +
                         "will get back to you as soon as they can."
                 })
-                .check.user.lang("zul")
                 .run();
         });
         it("should welcome the user if they don't have a subscription", function() {
@@ -480,7 +478,7 @@ describe("ussd_public app", function() {
             return tester
                 .setup(function(api) {
                     api.http.fixtures.add(
-                        fixtures_whatsapp.not_exists({
+                        fixtures_whatsapp.exists({
                             address: "+27123456789",
                             wait: true
                         })
@@ -491,20 +489,19 @@ describe("ussd_public app", function() {
                             null,
                             "whatsapp:27123456789",
                             {
-                                "on_whatsapp": "FALSE",
+                                "on_whatsapp": "TRUE",
                                 "research_consent": "FALSE",
-                                "language": "zul",
+                                "language": "eng",
                                 "source": "Public USSD",
                                 "timestamp": "2014-04-04T07:07:07Z",
                                 "registered_by": "+27123456789",
                                 "mha": 6,
-                                "swt": 1
+                                "swt": 7
                             }
                         )
                     );
                 })
                 .setup.user.state("state_opt_in")
-                .setup.user.lang("zul")
                 .input({session_event: "continue"})
                 .check.user.state("state_registration_complete")
                 .run();
@@ -560,7 +557,7 @@ describe("ussd_public app", function() {
                             {
                                 "on_whatsapp": "TRUE",
                                 "research_consent": "TRUE",
-                                "language": "xho",
+                                "language": "eng",
                                 "source": "Public USSD",
                                 "timestamp": "2014-04-04T07:07:07Z",
                                 "registered_by": "+27123456789",
@@ -573,7 +570,6 @@ describe("ussd_public app", function() {
                 .setup.user.state("state_trigger_rapidpro_flow")
                 .setup.user.answer("on_whatsapp", true)
                 .setup.user.answer("state_research_consent", "yes")
-                .setup.user.lang("xho")
                 .input({session_event: "continue"})
                 .check.user.state("state_registration_complete")
                 .run();
@@ -587,23 +583,22 @@ describe("ussd_public app", function() {
                             null,
                             "whatsapp:27123456789",
                             {
-                                "on_whatsapp": "FALSE",
+                                "on_whatsapp": "TRUE",
                                 "research_consent": "FALSE",
-                                "language": "zul",
+                                "language": "eng",
                                 "source": "Public USSD",
                                 "timestamp": "2014-04-04T07:07:07Z",
                                 "registered_by": "+27123456789",
                                 "mha": 6,
-                                "swt": 1
+                                "swt": 7
                             },
                             true
                         )
                     );
                 })
                 .setup.user.state("state_trigger_rapidpro_flow")
-                .setup.user.answer("on_whatsapp", false)
+                .setup.user.answer("on_whatsapp", true)
                 .setup.user.answer("state_research_consent", "no")
-                .setup.user.lang("zul")
                 .input({session_event: "continue"})
                 .check(function(api){
                     assert.equal(api.http.requests.length, 3);
@@ -634,7 +629,7 @@ describe("ussd_public app", function() {
                             {
                                 "on_whatsapp": "TRUE",
                                 "research_consent": "FALSE",
-                                "language": "zul",
+                                "language": "eng",
                                 "source": "Public USSD",
                                 "timestamp": "2014-04-04T07:07:07Z",
                                 "registered_by": "+27123456789",
@@ -647,7 +642,6 @@ describe("ussd_public app", function() {
                 // For some reason, if we start the test on state_registration_complete, it skips to state_start,
                 // so we need to start it before
                 .setup.user.state("state_whatsapp_contact_check")
-                .setup.user.lang("zul")
                 .setup.user.answer("on_whatsapp", false)
                 .input({session_event: "continue"})
                 .check.interaction({
@@ -667,35 +661,16 @@ describe("ussd_public app", function() {
                             wait: true
                         })
                     );
-                    api.http.fixtures.add(
-                        fixtures_rapidpro.start_flow(
-                            "rapidpro-flow-uuid",
-                            null,
-                            "whatsapp:27123456789",
-                            {
-                                "on_whatsapp": "FALSE",
-                                "research_consent": "FALSE",
-                                "language": "zul",
-                                "source": "Public USSD",
-                                "timestamp": "2014-04-04T07:07:07Z",
-                                "registered_by": "+27123456789",
-                                "mha": 6,
-                                "swt": 1
-                            }
-                        )
-                    );
                 })
                 // For some reason, if we start the test on state_registration_complete, it skips to state_start,
                 // so we need to start it before
                 .setup.user.state("state_whatsapp_contact_check")
-                .setup.user.lang("zul")
-                .setup.user.answer("on_whatsapp", false)
                 .input({session_event: "continue"})
                 .check.interaction({
-                    state: "state_registration_complete",
+                    state: "state_not_on_whatsapp",
                     reply:
-                        "You're done! This number 0123456789 will get helpful messages from MomConnect on SMS. " +
-                        "You can register for the full set of FREE messages at a clinic."
+                        "Sorry, MomConnect is not available on SMS. We only send WhatsApp messages in English. " +
+                        "You can dial *134*550*2# again on a cell number that has WhatsApp."
                 })
                 .run();
         });


### PR DESCRIPTION
This PR changes the welcome message, removes language selection defaulting to English, and shows an error instead of allowing users without a WhatsApp account to register.

This is all for the switching off of SMS for MomConnect. This does not address any changes required for the POPI line, those will be done in a separate PR