### PR TITLE
Don't allow switching back to SMS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_popi_rapidpro: [
                     'src/index.js',
+                    'src/engage.js',
                     'src/rapidpro.js',
                     '<%= paths.src.app.ussd_popi_rapidpro %>',
                     'src/init.js'
@@ -132,6 +133,7 @@ module.exports = function (grunt) {
                 ],
                 ussd_popi_rapidpro: [
                     'test/setup.js',
+                    'src/engage.js',
                     'src/rapidpro.js',
                     '<%= paths.src.app.ussd_popi_rapidpro %>',
                     'test/ussd_popi_rapidpro.test.js'

--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -307,50 +307,27 @@ go.app = function() {
         
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
+            var channel = _.get(contact, "fields.preferred_channel");
+
+            var sms_choices = [
+                new Choice("state_channel_switch_confirm", $("Change from SMS to WhatsApp")),
+                new Choice("state_msisdn_change_enter", $("Cell number")),
+                new Choice("state_language_change_enter", $("Language")),
+                new Choice("state_identification_change_type", $("Identification")),
+                new Choice("state_change_research_confirm", $("Research messages")),
+                new Choice("state_main_menu", $("Back"))
+            ];
+            var whatsapp_choices = [
+                new Choice("state_msisdn_change_enter", $("Cell number")),
+                new Choice("state_identification_change_type", $("Identification")),
+                new Choice("state_change_research_confirm", $("Research messages")),
+                new Choice("state_main_menu", $("Back"))
+            ];
             
-            return new ChoiceState(name, {
+            return new MenuState(name, {
                 question: $("What would you like to change?"),
                 error: $("Sorry we don't understand. Please try again."),
-                choices: [
-                    new Choice(
-                        "state_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact)
-                        })
-                    ),
-                    new Choice("state_msisdn_change_enter", $("Cell number")),
-                    new Choice("state_language_change_enter", $("Language")),
-                    new Choice("state_identification_change_type", $("Identification")),
-                    new Choice("state_change_research_confirm", $("Research messages")),
-                    new Choice("state_main_menu", $("Back")),
-                ],
-                next: function(choice) {
-                    if(choice.value === "state_language_change_enter") {
-                        if(_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP"){
-                            return "state_switch_to_sms_option";
-                        }
-                        else {
-                            return "state_language_change_enter";
-                        }
-                    }
-                    else{
-                        return choice.value;
-                    }
-                }
-            });
-        });
-
-        self.add("state_preferred_channel_language_option", function(name) {
-            return new MenuState(name, {
-                question: $("Please switch to SMS for msgs in another language"),
-                error: $("Sorry we don't recognise that reply. Please try again."
-                ),
-                choices: [
-                    new Choice("state_channel_switch_confirm", $("Switch to SMS (Dial *134*550*7# again when switch is done to " +
-                                            "pick your language)")),
-                    new Choice("state_exit", $("Exit")),
-                ]
+                choices: channel == "WhatsApp" ? whatsapp_choices : sms_choices
             });
         });
 

--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -1273,7 +1273,7 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_check_origin_contact"
+                next: "state_origin_msisdn_change_get_whatsapp_contact_background"
             });
         });
 
@@ -1485,8 +1485,25 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_check_target_contact"
+                next: "state_target_msisdn_whatsapp_contact_background"
             });
+        });
+
+        self.add("state_target_msisdn_whatsapp_contact_background", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_target_msisdn"), "ZA");
+            return self.whatsapp.contact_check(msisdn, false)
+                .then(function() {
+                    return self.states.create("state_check_target_contact");
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_check_target_contact", function(name, opts) {
@@ -1542,10 +1559,31 @@ go.app = function() {
                     "answer."
                 ),
                 choices: [
-                    new Choice("state_nosim_change_msisdn", $("Yes")),
+                    new Choice("state_target_msisdn_whatsapp_contact", $("Yes")),
                     new Choice("state_target_msisdn", $("No, I want to try again"))
                 ]
             });
+        });
+
+        self.add("state_target_msisdn_whatsapp_contact", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_target_msisdn"), "ZA");
+            return self.whatsapp.contact_check(msisdn, true)
+                .then(function(on_whatsapp) {
+                    if(on_whatsapp) {
+                        return self.states.create("state_nosim_change_msisdn");
+                    } else {
+                        return self.states.create("state_not_on_whatsapp");
+                    }
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_nosim_change_msisdn", function(name, opts) {

--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -1,6 +1,52 @@
 var go = {};
 go;
 
+go.Engage = function() {
+    var vumigo = require('vumigo_v02');
+    var events = vumigo.events;
+    var Eventable = events.Eventable;
+    var _ = require('lodash');
+    var url = require('url');
+
+    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
+        self.json_api = json_api;
+        self.base_url = base_url;
+        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
+        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
+
+        self.contact_check = function(msisdn, block) {
+            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
+                data: {
+                    blocking: block ? 'wait' : 'no_wait',
+                    contacts: [msisdn]
+                }
+            }).then(function(response) {
+                var existing = _.filter(response.data.contacts, function(obj) {
+                    return obj.status === "valid";
+                });
+                return !_.isEmpty(existing);
+            });
+        };
+
+          self.LANG_MAP = {zul_ZA: "en",
+                          xho_ZA: "en",
+                          afr_ZA: "af",
+                          eng_ZA: "en",
+                          nso_ZA: "en",
+                          tsn_ZA: "en",
+                          sot_ZA: "en",
+                          tso_ZA: "en",
+                          ssw_ZA: "en",
+                          ven_ZA: "en",
+                          nbl_ZA: "en",
+                        };
+    });
+
+
+
+    return Engage;
+}();
+
 go.RapidPro = function() {
     var vumigo = require('vumigo_v02');
     var url_utils = require('url');
@@ -149,6 +195,11 @@ go.app = function() {
                 new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-POPI"]}}),
                 self.im.config.services.rapidpro.base_url,
                 self.im.config.services.rapidpro.token
+            );
+            self.whatsapp = new go.Engage(
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
+                self.im.config.services.whatsapp.base_url,
+                self.im.config.services.whatsapp.token
             );
         };
 
@@ -442,8 +493,25 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_msisdn_change_get_contact"
+                next: "state_msisdn_change_get_whatsapp_contact_background"
             });
+        });
+
+        self.add("state_msisdn_change_get_whatsapp_contact_background", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_msisdn_change_enter"), "ZA");
+            return self.whatsapp.contact_check(msisdn, false)
+                .then(function() {
+                    return self.states.create("state_msisdn_change_get_contact");
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_msisdn_change_get_contact", function(name, opts) {
@@ -499,12 +567,44 @@ go.app = function() {
                     "You've entered {{msisdn}} as your new MomConnect number. Is this correct?"
                 ).context({msisdn: msisdn}),
                 choices: [
-                    new Choice("state_msisdn_change", $("Yes")),
+                    new Choice("state_msisdn_change_get_whatsapp_contact", $("Yes")),
                     new Choice("state_msisdn_change_enter", $("No, I want to try again"))
                 ],
                 error: $(
                     "Sorry we don't recognise that reply. Please enter the number next to your " +
                     "answer."
+                )
+            });
+        });
+
+        self.add("state_msisdn_change_get_whatsapp_contact", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_msisdn_change_enter"), "ZA");
+            return self.whatsapp.contact_check(msisdn, true)
+                .then(function(on_whatsapp) {
+                    if(on_whatsapp) {
+                        return self.states.create("state_msisdn_change");
+                    } else {
+                        return self.states.create("state_not_on_whatsapp");
+                    }
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
+        });
+
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                next: "state_start",
+                text: $(
+                    "The no. you're trying to switch to doesn't have WhatsApp. " +
+                    "MomConnect only sends WhatsApp msgs in English. " +
+                    "Dial *134*550*7# to switch to a no. with WhatsApp."
                 )
             });
         });

--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -230,17 +230,10 @@ go.app = function() {
         self.add("state_personal_info", function(name) {
             var contact = self.im.user.answers.contact;
             var id_type = _.get(contact, "fields.identification_type");
-            var text = $([
-                "Cell number: {{msisdn}}",
-                "Channel: {{channel}}",
-                "Language: {{language}}",
-                "{{id_type}}: {{id_details}}",
-                "Type: {{message_type}}",
-                "Research messages: {{research}}",
-                "Baby's birthday: {{dobs}}"
-            ].join("\n")).context({
+            var channel = _.get(contact, "fields.preferred_channel");
+            var context = {
                 msisdn: utils.readable_msisdn(self.im.user.addr, "27"),
-                channel: _.get(contact, "fields.preferred_channel") || $("None"),
+                channel: channel || $("None"),
                 language: _.get(self.languages, _.get(contact, "language"), $("None")),
                 id_type: _.get({
                     passport: $("Passport"),
@@ -273,7 +266,23 @@ go.app = function() {
                     new moment(_.get(contact, "fields.baby_dob3", null)),
                     new moment(_.get(contact, "fields.edd", null)),
                 ], _.method("isValid")), _.method("format", "YY-MM-DD")).join(", ") || $("None")
-            });
+            };
+            var sms_text = $([
+                "Cell number: {{msisdn}}",
+                "Channel: {{channel}}",
+                "Language: {{language}}",
+                "{{id_type}}: {{id_details}}",
+                "Type: {{message_type}}",
+                "Research messages: {{research}}",
+                "Baby's birthday: {{dobs}}"
+            ].join("\n")).context(context);
+            var whatsapp_text = $([
+                "Cell number: {{msisdn}}",
+                "{{id_type}}: {{id_details}}",
+                "Type: {{message_type}}",
+                "Research messages: {{research}}",
+                "Baby's birthday: {{dobs}}"
+            ].join("\n")).context(context);
             // Modified pagination logic to split on newline
             var page_end = function(i, text, n) {
                 var start = page_start(i, text, n);
@@ -287,7 +296,7 @@ go.app = function() {
                 return text.slice(page_start(i, text, n), page_end(i, text, n));
             };
             return new PaginatedState(name, {
-                text: text,
+                text: channel == "WhatsApp" ? whatsapp_text : sms_text,
                 back: $("Previous"),
                 more: $("Next"),
                 exit: $("Back"),

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -47,6 +47,11 @@ go.app = function() {
                 self.im.config.services.rapidpro.base_url,
                 self.im.config.services.rapidpro.token
             );
+            self.whatsapp = new go.Engage(
+                new JsonApi(self.im, {headers: {'User-Agent': ["Jsbox/NDoH-Clinic"]}}),
+                self.im.config.services.whatsapp.base_url,
+                self.im.config.services.whatsapp.token
+            );
         };
 
         self.contact_current_channel = function(contact) {
@@ -339,8 +344,25 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_msisdn_change_get_contact"
+                next: "state_msisdn_change_get_whatsapp_contact_background"
             });
+        });
+
+        self.add("state_msisdn_change_get_whatsapp_contact_background", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_msisdn_change_enter"), "ZA");
+            return self.whatsapp.contact_check(msisdn, false)
+                .then(function() {
+                    return self.states.create("state_msisdn_change_get_contact");
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_msisdn_change_get_contact", function(name, opts) {
@@ -396,12 +418,44 @@ go.app = function() {
                     "You've entered {{msisdn}} as your new MomConnect number. Is this correct?"
                 ).context({msisdn: msisdn}),
                 choices: [
-                    new Choice("state_msisdn_change", $("Yes")),
+                    new Choice("state_msisdn_change_get_whatsapp_contact", $("Yes")),
                     new Choice("state_msisdn_change_enter", $("No, I want to try again"))
                 ],
                 error: $(
                     "Sorry we don't recognise that reply. Please enter the number next to your " +
                     "answer."
+                )
+            });
+        });
+
+        self.add("state_msisdn_change_get_whatsapp_contact", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_msisdn_change_enter"), "ZA");
+            return self.whatsapp.contact_check(msisdn, true)
+                .then(function(on_whatsapp) {
+                    if(on_whatsapp) {
+                        return self.states.create("state_msisdn_change");
+                    } else {
+                        return self.states.create("state_not_on_whatsapp");
+                    }
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
+        });
+
+        self.states.add("state_not_on_whatsapp", function(name) {
+            return new EndState(name, {
+                next: "state_start",
+                text: $(
+                    "The no. you're trying to switch to doesn't have WhatsApp. " +
+                    "MomConnect only sends WhatsApp msgs in English. " +
+                    "Dial *134*550*7# to switch to a no. with WhatsApp."
                 )
             });
         });

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -1124,7 +1124,7 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_check_origin_contact"
+                next: "state_origin_msisdn_change_get_whatsapp_contact_background"
             });
         });
 
@@ -1336,8 +1336,25 @@ go.app = function() {
                         );
                     }
                 },
-                next: "state_check_target_contact"
+                next: "state_target_msisdn_whatsapp_contact_background"
             });
+        });
+
+        self.add("state_target_msisdn_whatsapp_contact_background", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_target_msisdn"), "ZA");
+            return self.whatsapp.contact_check(msisdn, false)
+                .then(function() {
+                    return self.states.create("state_check_target_contact");
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_check_target_contact", function(name, opts) {
@@ -1393,10 +1410,31 @@ go.app = function() {
                     "answer."
                 ),
                 choices: [
-                    new Choice("state_nosim_change_msisdn", $("Yes")),
+                    new Choice("state_target_msisdn_whatsapp_contact", $("Yes")),
                     new Choice("state_target_msisdn", $("No, I want to try again"))
                 ]
             });
+        });
+
+        self.add("state_target_msisdn_whatsapp_contact", function(name, opts) {
+            var msisdn = utils.normalize_msisdn(
+                _.get(self.im.user.answers, "state_target_msisdn"), "ZA");
+            return self.whatsapp.contact_check(msisdn, true)
+                .then(function(on_whatsapp) {
+                    if(on_whatsapp) {
+                        return self.states.create("state_nosim_change_msisdn");
+                    } else {
+                        return self.states.create("state_not_on_whatsapp");
+                    }
+                }).catch(function(e) {
+                    // Go to error state after 3 failed HTTP requests
+                    opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                    if(opts.http_error_count === 3) {
+                        self.im.log.error(e.message);
+                        return self.states.create("__error__", {return_state: name});
+                    }
+                    return self.states.create(name, opts);
+                });
         });
 
         self.add("state_nosim_change_msisdn", function(name, opts) {

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -204,50 +204,27 @@ go.app = function() {
         
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
+            var channel = _.get(contact, "fields.preferred_channel");
+
+            var sms_choices = [
+                new Choice("state_channel_switch_confirm", $("Change from SMS to WhatsApp")),
+                new Choice("state_msisdn_change_enter", $("Cell number")),
+                new Choice("state_language_change_enter", $("Language")),
+                new Choice("state_identification_change_type", $("Identification")),
+                new Choice("state_change_research_confirm", $("Research messages")),
+                new Choice("state_main_menu", $("Back"))
+            ];
+            var whatsapp_choices = [
+                new Choice("state_msisdn_change_enter", $("Cell number")),
+                new Choice("state_identification_change_type", $("Identification")),
+                new Choice("state_change_research_confirm", $("Research messages")),
+                new Choice("state_main_menu", $("Back"))
+            ];
             
-            return new ChoiceState(name, {
+            return new MenuState(name, {
                 question: $("What would you like to change?"),
                 error: $("Sorry we don't understand. Please try again."),
-                choices: [
-                    new Choice(
-                        "state_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact)
-                        })
-                    ),
-                    new Choice("state_msisdn_change_enter", $("Cell number")),
-                    new Choice("state_language_change_enter", $("Language")),
-                    new Choice("state_identification_change_type", $("Identification")),
-                    new Choice("state_change_research_confirm", $("Research messages")),
-                    new Choice("state_main_menu", $("Back")),
-                ],
-                next: function(choice) {
-                    if(choice.value === "state_language_change_enter") {
-                        if(_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP"){
-                            return "state_switch_to_sms_option";
-                        }
-                        else {
-                            return "state_language_change_enter";
-                        }
-                    }
-                    else{
-                        return choice.value;
-                    }
-                }
-            });
-        });
-
-        self.add("state_preferred_channel_language_option", function(name) {
-            return new MenuState(name, {
-                question: $("Please switch to SMS for msgs in another language"),
-                error: $("Sorry we don't recognise that reply. Please try again."
-                ),
-                choices: [
-                    new Choice("state_channel_switch_confirm", $("Switch to SMS (Dial *134*550*7# again when switch is done to " +
-                                            "pick your language)")),
-                    new Choice("state_exit", $("Exit")),
-                ]
+                choices: channel == "WhatsApp" ? whatsapp_choices : sms_choices
             });
         });
 

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -290,14 +290,14 @@ describe("ussd_popi_rapidpro app", function() {
         });
     });
     describe("state_change_info", function(){
-        it("should display the list of options to the user", function() {
+        it("should display the list of options to the user SMS", function() {
             return tester
                 .setup.user.state("state_change_info")
-                .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
                 .check.interaction({
                     reply: [
                         "What would you like to change?",
-                        "1. Change from WhatsApp to SMS",
+                        "1. Change from SMS to WhatsApp",
                         "2. Cell number",
                         "3. Language",
                         "4. Identification",
@@ -307,15 +307,30 @@ describe("ussd_popi_rapidpro app", function() {
                 })
                 .run();
         });
-        it("should display an error on invalid input", function() {
+        it("should display the list of options to the user WhatsApp", function() {
             return tester
                 .setup.user.state("state_change_info")
                 .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
+                .check.interaction({
+                    reply: [
+                        "What would you like to change?",
+                        "1. Cell number",
+                        "2. Identification",
+                        "3. Research messages",
+                        "4. Back"
+                    ].join("\n")
+                })
+                .run();
+        });
+        it("should display an error on invalid input", function() {
+            return tester
+                .setup.user.state("state_change_info")
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
                 .input("A")
                 .check.interaction({
                     reply: [
                         "Sorry we don't understand. Please try again.",
-                        "1. Change from WhatsApp to SMS",
+                        "1. Change from SMS to WhatsApp",
                         "2. Cell number",
                         "3. Language",
                         "4. Identification",
@@ -328,7 +343,7 @@ describe("ussd_popi_rapidpro app", function() {
         it("should go to state_channel_switch_confirm if that option is chosen", function() {
             return tester
                 .setup.user.state("state_change_info")
-                .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
                 .input("1")
                 .check.user.state("state_channel_switch_confirm")
                 .run();
@@ -337,7 +352,7 @@ describe("ussd_popi_rapidpro app", function() {
             return tester
                 .setup.user.state("state_change_info")
                 .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
-                .input("2")
+                .input("1")
                 .check.user.state("state_msisdn_change_enter")
                 .run();
         });
@@ -349,85 +364,12 @@ describe("ussd_popi_rapidpro app", function() {
                 .check.user.state("state_language_change_enter")
                 .run();
         });
-        it("should got to state_switch_to_sms_option if WA is channel", function() {
-            return tester
-                .setup.user.state("state_change_info")
-                .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
-                .input("3")
-                .check.interaction({
-                    reply: [
-                        "Please switch to SMS for msgs in another language",
-                        "1. Switch to SMS (Dial *134*550*7# again when switch is done to " +
-                            "pick your language)",
-                        "2. Exit"
-                    ].join("\n"),
-                    state: "state_switch_to_sms_option"
-                })
-                .run();
-        });
         it("should go to state_identification_change_type if that option is chosen", function() {
             return tester
                 .setup.user.state("state_change_info")
                 .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
-                .input("4")
-                .check.user.state("state_identification_change_type")
-                .run();
-        });
-    });
-    describe("state_preferred_channel_language_option", function() {
-        it("should ask the user what they want to do", function() {
-            return tester
-                .setup.user.state("state_preferred_channel_language_option")
-                .check.interaction({
-                    reply: [
-                        "Please switch to SMS for msgs in another language",
-                        "1. Switch to SMS (Dial *134*550*7# again when switch is done to " +
-                            "pick your language)",
-                        "2. Exit"
-                    ].join("\n"),
-                })
-                .run();
-        });
-        it("should show an error on invalid input", function() {
-            return tester
-                .setup.user.state("state_preferred_channel_language_option")
-                .input("A")
-                .check.interaction({
-                    reply: [
-                        "Sorry we don't recognise that reply. Please try again.",
-                        "1. Switch to SMS (Dial *134*550*7# again when switch is done to " +
-                            "pick your language)",
-                        "2. Exit"
-                    ].join("\n")
-                })
-                .run();
-        });
-        it("should exit if the user chooses to", function() {
-            return tester
-                .setup.user.state("state_preferred_channel_language_option")
                 .input("2")
-                .check.interaction({
-                    reply:
-                        "Thanks for using MomConnect. You can dial *134*550*7# any time to manage " +
-                        "your info. Have a lovely day!",
-                    state: "state_exit"
-                })
-                .check.reply.ends_session()
-                .run();
-        });
-        it("should ask the user if they want to switch channels to SMS", function() {
-            return tester
-                .setup.user.state("state_preferred_channel_language_option")
-                .setup.user.answer("contact", {fields: {preferred_channel: "WhatsApp"}})
-                .input("1")
-                .check.interaction({
-                    reply: [
-                        "Are you sure you want to get your MomConnect messages on SMS?",
-                        "1. Yes",
-                        "2. No"
-                    ].join("\n"),
-                    state: "state_channel_switch_confirm"
-                })
+                .check.user.state("state_identification_change_type")
                 .run();
         });
     });

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -1989,6 +1989,12 @@ describe("ussd_popi_rapidpro app", function() {
                 .setup.user.state("state_target_msisdn")
                 .setup(function(api) {
                     api.http.fixtures.add(
+                        fixtures_whatsapp.exists({
+                            address: "+27820001001",
+                            wait: false
+                        })
+                    );
+                    api.http.fixtures.add(
                         fixtures_rapidpro.get_contact({
                             urn: "whatsapp:27820001001",
                             exists: true,
@@ -2004,6 +2010,12 @@ describe("ussd_popi_rapidpro app", function() {
             return tester
                 .setup.user.state("state_target_msisdn")
                 .setup(function(api) {
+                    api.http.fixtures.add(
+                        fixtures_whatsapp.exists({
+                            address: "+27820001001",
+                            wait: false
+                        })
+                    );
                     api.http.fixtures.add(
                         fixtures_rapidpro.get_contact({
                             urn: "whatsapp:27820001001",
@@ -2080,6 +2092,12 @@ describe("ussd_popi_rapidpro app", function() {
                 .setup.user.state("state_target_no_subscriptions")
                 .setup(function(api) {
                     api.http.fixtures.add(
+                        fixtures_whatsapp.exists({
+                            address: "+27820001001",
+                            wait: true
+                        })
+                    );
+                    api.http.fixtures.add(
                         fixtures_rapidpro.start_flow(
                             "msisdn-change-flow", null, "whatsapp:27820001001", {
                                 new_msisdn: "+27820001001",
@@ -2098,6 +2116,27 @@ describe("ussd_popi_rapidpro app", function() {
                 })
                 .input("1")
                 .check.user.state("state_nosim_change_success")
+                .run();
+        });
+        it("should show an error if the target number doesn't have WhatsApp", function () {
+            return tester
+                .setup.user.state("state_target_no_subscriptions")
+                .setup(function(api) {
+                    api.http.fixtures.add(
+                        fixtures_whatsapp.not_exists({
+                            address: "+27820001001",
+                            wait: true
+                        })
+                    );
+                })
+                .setup.user.answer("state_target_msisdn")
+                .setup.user.answers({
+                    state_target_msisdn: "0820001001",
+                    state_enter_origin_msisdn: "0820001002",
+                    origin_contact: {uuid: "contact-uuid"}
+                })
+                .input("1")
+                .check.user.state("state_not_on_whatsapp")
                 .run();
         });
     });

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -204,7 +204,7 @@ describe("ussd_popi_rapidpro app", function() {
                 })
                 .run();
         });
-        it("should display contact data page 1", function() {
+        it("should display contact data WhatsApp", function() {
             return tester
                 .setup.user.state("state_personal_info")
                 .setup.user.answer("contact", {
@@ -223,7 +223,35 @@ describe("ussd_popi_rapidpro app", function() {
                 .check.interaction({
                     reply: [
                         "Cell number: 0123456789",
-                        "Channel: WhatsApp",
+                        "Passport: A12345 Malawi",
+                        "Type: Pregnancy",
+                        "Research messages: Yes",
+                        "Baby's birthday: 18-03-02, 20-06-04",
+                        "1. Back"
+                    ].join("\n")
+                })
+                .run();
+        });
+        it("should display contact data page 1 SMS", function() {
+            return tester
+                .setup.user.state("state_personal_info")
+                .setup.user.answer("contact", {
+                    language: "zul",
+                    fields: {
+                        preferred_channel: "SMS",
+                        identification_type: "passport",
+                        passport_number: "A12345",
+                        passport_origin: "mw",
+                        research_consent: "TRUE",
+                        edd: "2020-06-04T00:00:00.000000Z",
+                        baby_dob1: "2018-03-02T00:00:00.000000Z",
+                        prebirth_messaging: "1"
+                    },
+                })
+                .check.interaction({
+                    reply: [
+                        "Cell number: 0123456789",
+                        "Channel: SMS",
                         "Language: isiZulu",
                         "Passport: A12345 Malawi",
                         "Type: Pregnancy",
@@ -240,7 +268,7 @@ describe("ussd_popi_rapidpro app", function() {
                 .setup.user.answer("contact", {
                     language: "zul",
                     fields: {
-                        preferred_channel: "WhatsApp",
+                        preferred_channel: "SMS",
                         identification_type: "passport",
                         passport_number: "A12345",
                         passport_origin: "mw",


### PR DESCRIPTION
There are 2 parts to this
1. We don't give the option to switch channels if they're on WhatsApp
2. If they change numbers, then the target number must be on WhatsApp