### PR TITLE
added npm grunt-pot, as jspot is no longer supported

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,8 +3,21 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-pot');
 
     grunt.initConfig({
+        pot: {
+            options:{
+          text_domain: 'my-text-domain', //Your text domain. Produces my-text-domain.pot
+          dest: 'config/', //directory to place the pot file
+          keywords: [ '$' ], //functions to look for
+          msgmerge: true
+          },
+          files:{
+            src:  [ '**/*.js' ], //Parse all .js files
+            expand: true,
+             }
+        },
         paths: {
             src: {
                 app: {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
   },
   "devDependencies": {
     "csv-parse": "^4.14.0",
-    "grunt": "~1.0.3",
+    "grunt": "^1.3.0",
     "grunt-cli": "~1.3.2",
     "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-jshint": "~1.1.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-mocha-test": "~0.13.3",
+    "grunt-pot": "^0.3.0",
     "jshint": "~2.9.5",
     "mocha": "~5.0.1"
   }


### PR DESCRIPTION
In this PR, I have added `grunt-pot`, as `jspot` is no longer supported

see this https://www.npmjs.com/package/grunt-pot for reference