### PR TITLE
Get prebirth value rather than true or false and pull more fields

### DIFF
--- a/go-app-ussd_mcgcc_rapidpro.js
+++ b/go-app-ussd_mcgcc_rapidpro.js
@@ -439,6 +439,8 @@ go.app = function() {
             var baby_dob1 = (contact.fields.baby_dob1) ? moment.utc(contact.fields.baby_dob1).format() : null;
             var baby_dob2 = (contact.fields.baby_dob2) ? moment.utc(contact.fields.baby_dob2).format() : null;
             var baby_dob3 = (contact.fields.baby_dob3) ? moment.utc(contact.fields.baby_dob3).format() : null;
+            var prebirth_messaging = _.get(contact, "fields.prebirth_messaging", null);
+            var postbirth_messaging = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
             var mom_edd = (contact.fields.edd) ? moment.utc(contact.fields.edd).format() : null;
             var supporter_cell = utils.normalize_msisdn(self.im.user.get_answer("state_mother_supporter_msisdn"), "ZA");
             var supp_consent = _.toUpper(self.im.user.get_answer("state_mother_supporter_consent"));
@@ -450,6 +452,8 @@ go.app = function() {
                 baby_dob1: baby_dob1,
                 baby_dob2: baby_dob2,
                 baby_dob3: baby_dob3,
+                prebirth_messaging: prebirth_messaging,
+                postbirth_messaging: postbirth_messaging,
                 mom_edd: mom_edd,
                 source: "USSD",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
@@ -692,11 +696,18 @@ go.app = function() {
         });
 
         self.add("state_trigger_supporter_registration_flow", function(name, opts) {
+            var contact = self.im.user.get_answer("contact");
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             var supporter_consent = _.toUpper(self.im.user.get_answer("state_supporter_consent"));
             var supporter_no_consent = _.toUpper(self.im.user.get_answer("state_supporter_noconsent_ask_again"));
             var supporters_language;
             var research_consent = _.toUpper(self.im.user.get_answer("state_supporter_research_consent"));
+            var baby_dob1 = (contact.fields.baby_dob1) ? moment.utc(contact.fields.baby_dob1).format() : null;
+            var baby_dob2 = (contact.fields.baby_dob2) ? moment.utc(contact.fields.baby_dob2).format() : null;
+            var baby_dob3 = (contact.fields.baby_dob3) ? moment.utc(contact.fields.baby_dob3).format() : null;
+            var prebirth_messaging = _.get(contact, "fields.prebirth_messaging", null);
+            var postbirth_messaging = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
+            var mom_edd = (contact.fields.edd) ? moment.utc(contact.fields.edd).format() : null;
 
             if (typeof self.im.user.get_answer("state_supporter_language_whatsapp") === "undefined") {
                 supporters_language = self.im.user.get_answer("state_supporter_language_sms");
@@ -714,6 +725,12 @@ go.app = function() {
                 on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false",
                 supp_consent: supporter_consent,
                 research_consent: (research_consent === "YES" || research_consent === "1") ? "true" : "false",
+                baby_dob1: baby_dob1,
+                baby_dob2: baby_dob2,
+                baby_dob3: baby_dob3,
+                prebirth_messaging: prebirth_messaging,
+                postbirth_messaging: postbirth_messaging,
+                mom_edd: mom_edd,
                 supp_cell: msisdn,
                 supp_language: supporters_language,
                 supp_relationship: self.im.user.get_answer("state_supporter_relationship"),

--- a/src/ussd_mcgcc_rapidpro.js
+++ b/src/ussd_mcgcc_rapidpro.js
@@ -290,6 +290,8 @@ go.app = function() {
             var baby_dob1 = (contact.fields.baby_dob1) ? moment.utc(contact.fields.baby_dob1).format() : null;
             var baby_dob2 = (contact.fields.baby_dob2) ? moment.utc(contact.fields.baby_dob2).format() : null;
             var baby_dob3 = (contact.fields.baby_dob3) ? moment.utc(contact.fields.baby_dob3).format() : null;
+            var prebirth_messaging = _.get(contact, "fields.prebirth_messaging", null);
+            var postbirth_messaging = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
             var mom_edd = (contact.fields.edd) ? moment.utc(contact.fields.edd).format() : null;
             var supporter_cell = utils.normalize_msisdn(self.im.user.get_answer("state_mother_supporter_msisdn"), "ZA");
             var supp_consent = _.toUpper(self.im.user.get_answer("state_mother_supporter_consent"));
@@ -301,6 +303,8 @@ go.app = function() {
                 baby_dob1: baby_dob1,
                 baby_dob2: baby_dob2,
                 baby_dob3: baby_dob3,
+                prebirth_messaging: prebirth_messaging,
+                postbirth_messaging: postbirth_messaging,
                 mom_edd: mom_edd,
                 source: "USSD",
                 timestamp: new moment.utc(self.im.config.testing_today).format(),
@@ -543,11 +547,18 @@ go.app = function() {
         });
 
         self.add("state_trigger_supporter_registration_flow", function(name, opts) {
+            var contact = self.im.user.get_answer("contact");
             var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
             var supporter_consent = _.toUpper(self.im.user.get_answer("state_supporter_consent"));
             var supporter_no_consent = _.toUpper(self.im.user.get_answer("state_supporter_noconsent_ask_again"));
             var supporters_language;
             var research_consent = _.toUpper(self.im.user.get_answer("state_supporter_research_consent"));
+            var baby_dob1 = (contact.fields.baby_dob1) ? moment.utc(contact.fields.baby_dob1).format() : null;
+            var baby_dob2 = (contact.fields.baby_dob2) ? moment.utc(contact.fields.baby_dob2).format() : null;
+            var baby_dob3 = (contact.fields.baby_dob3) ? moment.utc(contact.fields.baby_dob3).format() : null;
+            var prebirth_messaging = _.get(contact, "fields.prebirth_messaging", null);
+            var postbirth_messaging = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
+            var mom_edd = (contact.fields.edd) ? moment.utc(contact.fields.edd).format() : null;
 
             if (typeof self.im.user.get_answer("state_supporter_language_whatsapp") === "undefined") {
                 supporters_language = self.im.user.get_answer("state_supporter_language_sms");
@@ -565,6 +576,12 @@ go.app = function() {
                 on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false",
                 supp_consent: supporter_consent,
                 research_consent: (research_consent === "YES" || research_consent === "1") ? "true" : "false",
+                baby_dob1: baby_dob1,
+                baby_dob2: baby_dob2,
+                baby_dob3: baby_dob3,
+                prebirth_messaging: prebirth_messaging,
+                postbirth_messaging: postbirth_messaging,
+                mom_edd: mom_edd,
                 supp_cell: msisdn,
                 supp_language: supporters_language,
                 supp_relationship: self.im.user.get_answer("state_supporter_relationship"),

--- a/test/ussd_mcgcc_rapidpro.test.js
+++ b/test/ussd_mcgcc_rapidpro.test.js
@@ -346,7 +346,8 @@ describe("ussd_mcgcc app", function() {
                     contact: {
                         fields: {
                             baby_dob1: "2021-01-06T07:07:07",
-                            edd: "2021-01-06T07:07:07"
+                            edd: "2021-01-06T07:07:07",
+                            prebirth_messaging: 1
                         }
                     }
                 })
@@ -363,6 +364,8 @@ describe("ussd_mcgcc app", function() {
                                 "baby_dob1": "2021-01-06T07:07:07Z",
                                 "baby_dob2": null,
                                 "baby_dob3": null,
+                                "prebirth_messaging": 1,
+                                "postbirth_messaging": false,
                                 "mom_edd": "2021-01-06T07:07:07Z",
                                 "source": "USSD",
                                 "timestamp": "2021-03-06T07:07:07Z",
@@ -390,7 +393,8 @@ describe("ussd_mcgcc app", function() {
                     contact: {
                         fields: {
                             baby_dob1: "2021-01-06T07:07:07",
-                            edd: "2021-01-06T07:07:07"
+                            edd: "2021-01-06T07:07:07",
+                            prebirth_messaging: 1
                         }
                     }
                 })
@@ -407,6 +411,8 @@ describe("ussd_mcgcc app", function() {
                                 "baby_dob1": "2021-01-06T07:07:07Z",
                                 "baby_dob2": null,
                                 "baby_dob3": null,
+                                "prebirth_messaging": 1,
+                                "postbirth_messaging": false,
                                 "mom_edd": "2021-01-06T07:07:07Z",
                                 "source": "USSD",
                                 "timestamp": "2021-03-06T07:07:07Z",
@@ -659,7 +665,14 @@ describe("ussd_mcgcc app", function() {
                     state_supporter_language_whatsapp: "eng_ZA",
                     state_supporter_name: "John",
                     state_supporter_research_consent: "Yes",
-                    state_supporter_relationship: "father"
+                    state_supporter_relationship: "father",
+                    contact: {
+                        fields: {
+                            baby_dob1: "2021-01-06T07:07:07",
+                            edd: "2021-01-06T07:07:07",
+                            prebirth_messaging: 1
+                        }
+                    }
                 })
                 .setup(function(api) {
                     api.http.fixtures.add(
@@ -670,6 +683,12 @@ describe("ussd_mcgcc app", function() {
                                 "on_whatsapp": "true",
                                 "supp_consent": "true",
                                 "research_consent": "true",
+                                "baby_dob1": "2021-01-06T07:07:07Z",
+                                "baby_dob2": null,
+                                "baby_dob3": null,
+                                "prebirth_messaging": 1,
+                                "postbirth_messaging": false,
+                                "mom_edd": "2021-01-06T07:07:07Z",
                                 "supp_cell": "+27123456789",
                                 "supp_language": "eng_ZA",
                                 "supp_name": "John",
@@ -698,7 +717,14 @@ describe("ussd_mcgcc app", function() {
                     state_supporter_language_whatsapp: "eng_ZA",
                     state_supporter_name: "John",
                     state_supporter_research_consent: "Yes",
-                    state_supporter_relationship: "father"
+                    state_supporter_relationship: "father",
+                    contact: {
+                        fields: {
+                            baby_dob1: "2021-01-06T07:07:07",
+                            edd: "2021-01-06T07:07:07",
+                            prebirth_messaging: 1
+                        }
+                    }
                 })
                 .setup(function(api) {
                     api.http.fixtures.add(
@@ -709,6 +735,12 @@ describe("ussd_mcgcc app", function() {
                                 "on_whatsapp": "true",
                                 "supp_consent": "true",
                                 "research_consent": "true",
+                                "baby_dob1": "2021-01-06T07:07:07Z",
+                                "baby_dob2": null,
+                                "baby_dob3": null,
+                                "prebirth_messaging": 1,
+                                "postbirth_messaging": false,
+                                "mom_edd": "2021-01-06T07:07:07Z",
                                 "supp_cell": "+27123456789",
                                 "supp_language": "eng_ZA",
                                 "supp_name": "John",


### PR DESCRIPTION
This PR does the following:
* Pulls the actual value of prebirth field rather True or False if it exists (range is 1 - 7)
* Pull prebirth and postbirth data from mother. We need this in the  supporter suggestion flow
* Does the same for supporter registration flow. We realized it's necessary to pull from these fields during the time a supporter is suggested and when they register because in-between the mother could change her details.