### PR TITLE
Feature mcgcc partner messaging

### DIFF
--- a/go-app-ussd_mcgcc_rapidpro.js
+++ b/go-app-ussd_mcgcc_rapidpro.js
@@ -882,44 +882,30 @@ go.app = function() {
 
         self.add('state_supporter_change_info', function(name) {
             var contact = self.im.user.answers.contact;
-            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
-                return self.states.create("state_supporter_change_info_WA");
-              }
+            var choices = [
+                new Choice("state_supporter_new_name", $("Name")),
+                new Choice("state_supporter_new_language_whatsapp", $("Language")),
+                new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
+                
+                new Choice("state_supporter_channel_switch_confirm",
+                    $("Change from {{current_channel}} to {{alternative_channel}}").context({
+                        current_channel: self.contact_current_channel(contact),
+                        alternative_channel: self.contact_alternative_channel(contact),
+                    })),
+                new Choice("state_supporter_new_research_consent", $("Research Consent")),
+                new Choice("state_supporter_profile", $("Back"))
+            ];
+            var preferred_channel = (_.toUpper(_.get(contact, "fields.preferred_channel")));
+            if (preferred_channel === "WHATSAPP"){
+                choices.splice(3,1);
+            }
             return new MenuState(name, {
                 question: $(
                     "What would you like to change?"),
                 error: $(
                     "Please try again. Reply with the nr that matches your answer."),
                 accept_labels: true,
-                choices: [
-                    new Choice("state_supporter_new_name", $("Name")),
-                    new Choice("state_supporter_new_language_whatsapp", $("Language")),
-                    new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact),
-                        })),
-                    new Choice("state_supporter_new_research_consent", $("Research Consent")),
-                    new Choice("state_supporter_profile", $("Back"))
-                ]
-            });
-        });
-
-        self.add('state_supporter_change_info_WA', function(name) {
-            return new MenuState(name, {
-                question: $(
-                    "What would you like to change?"),
-                error: $(
-                    "Please try again. Reply with the nr that matches your answer."),
-                accept_labels: true,
-                choices: [
-                    new Choice("state_supporter_new_name", $("Name")),
-                    new Choice("state_supporter_new_language_whatsapp", $("Language")),
-                    new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_new_research_consent", $("Research Consent")),
-                    new Choice("state_supporter_profile", $("Back"))
-                ]
+                choices: choices
             });
         });
 

--- a/go-app-ussd_mcgcc_rapidpro.js
+++ b/go-app-ussd_mcgcc_rapidpro.js
@@ -881,7 +881,6 @@ go.app = function() {
         });
 
         self.add('state_supporter_change_info', function(name) {
-            var contact = self.im.user.answers.contact;
             return new MenuState(name, {
                 question: $(
                     "What would you like to change?"),
@@ -892,11 +891,6 @@ go.app = function() {
                     new Choice("state_supporter_new_name", $("Name")),
                     new Choice("state_supporter_new_language_whatsapp", $("Language")),
                     new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact),
-                        })),
                     new Choice("state_supporter_new_research_consent", $("Research Consent")),
                     new Choice("state_supporter_profile", $("Back"))
                 ]
@@ -1205,83 +1199,6 @@ go.app = function() {
                 }),
             });
         });
-
-        self.add("state_supporter_channel_switch_confirm", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-                question: $("Are you sure you want to get your MomConnect messages on " +
-                "{{alternative_channel}}?").context({
-                    alternative_channel: self.contact_alternative_channel(contact)
-                }),
-                choices: [
-                    new Choice("state_supporter_channel_switch_rapidpro", $("Yes")),
-                    new Choice("state_no_channel_switch", $("No")),
-                ],
-                error: $("Sorry we don't recognise that reply. " + 
-                "Please enter the number next to your answer.")
-            });
-        });
-
-        self.add("state_no_channel_switch", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-              question: $(
-                "You'll keep getting your messages on {{channel}}. If you change your mind, " +
-                "dial *134*550*9#. What would you like to do?"
-              ).context({ channel: self.contact_current_channel(contact) }),
-              choices: [
-                new Choice("state_start", $("Back to main menu")),
-                new Choice("state_exit", $("Exit"))
-              ],
-              error: $("Sorry we don't recognise that reply. " + 
-                "Please enter the number next to your answer.")
-            });
-        });
-
-        self.add("state_supporter_channel_switch_rapidpro", function (name, opts) {
-            var contact = self.im.user.answers.contact, flow_uuid;
-            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
-              flow_uuid = self.im.config.sms_switch_flow_uuid;
-            } else {
-              flow_uuid = self.im.config.whatsapp_switch_flow_uuid;
-            }
-            var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
-      
-            return self.rapidpro
-              .start_flow(flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"))
-              .then(function () {
-                return self.states.create("state_supporter_channel_switch_success");
-              }).catch(function (e) {
-                // Go to error state after 3 failed HTTP requests
-                opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
-                if (opts.http_error_count === 3) {
-                  self.im.log.error(e.message);
-                  return self.states.create("__error__", { return_state: name });
-                }
-                return self.states.create(name, opts);
-              });
-        });
-
-        self.add("state_supporter_channel_switch_success", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-              question: $(
-                "Okay. I'll send you MomConnect messages on {{alternative_channel}}. " +
-                "To move back to {{current_channel}}, dial *134*550*9#."
-              ).context({
-                alternative_channel: self.contact_alternative_channel(contact),
-                current_channel: self.contact_current_channel(contact)
-              }),
-              choices: [
-                new Choice("state_supporter_profile", $("Back")),
-                new Choice("state_exit", $("Exit"))
-              ],
-              error: $(
-                "Sorry we don't recognise that reply. Please enter the number next to your " +
-                "answer."
-              )
-            });
-          });
 
         self.add("state_supporter_new_research_consent", function(name) {
             return new ChoiceState(name, {

--- a/go-app-ussd_mcgcc_rapidpro.js
+++ b/go-app-ussd_mcgcc_rapidpro.js
@@ -879,7 +879,7 @@ go.app = function() {
                 ]
             });
         });
-        
+
         self.add('state_supporter_change_info', function(name) {
             var contact = self.im.user.answers.contact;
             if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
@@ -1016,8 +1016,6 @@ go.app = function() {
                 next: "state_supporter_change_language_rapidpro"
             });
         });
-
-
 
         self.add("state_supporter_new_language_sms", function(name) {
             return new ChoiceState(name, {

--- a/src/ussd_mcgcc_rapidpro.js
+++ b/src/ussd_mcgcc_rapidpro.js
@@ -730,8 +730,34 @@ go.app = function() {
                 ]
             });
         });
-
+        
         self.add('state_supporter_change_info', function(name) {
+            var contact = self.im.user.answers.contact;
+            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
+                return self.states.create("state_supporter_change_info_WA");
+              }
+            return new MenuState(name, {
+                question: $(
+                    "What would you like to change?"),
+                error: $(
+                    "Please try again. Reply with the nr that matches your answer."),
+                accept_labels: true,
+                choices: [
+                    new Choice("state_supporter_new_name", $("Name")),
+                    new Choice("state_supporter_new_language_whatsapp", $("Language")),
+                    new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
+                    new Choice("state_supporter_channel_switch_confirm",
+                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
+                            current_channel: self.contact_current_channel(contact),
+                            alternative_channel: self.contact_alternative_channel(contact),
+                        })),
+                    new Choice("state_supporter_new_research_consent", $("Research Consent")),
+                    new Choice("state_supporter_profile", $("Back"))
+                ]
+            });
+        });
+
+        self.add('state_supporter_change_info_WA', function(name) {
             return new MenuState(name, {
                 question: $(
                     "What would you like to change?"),
@@ -1050,6 +1076,83 @@ go.app = function() {
                 }),
             });
         });
+
+        self.add("state_supporter_channel_switch_confirm", function (name) {
+            var contact = self.im.user.answers.contact;
+            return new MenuState(name, {
+                question: $("Are you sure you want to get your MomConnect messages on " +
+                "{{alternative_channel}}?").context({
+                    alternative_channel: self.contact_alternative_channel(contact)
+                }),
+                choices: [
+                    new Choice("state_supporter_channel_switch_rapidpro", $("Yes")),
+                    new Choice("state_no_channel_switch", $("No")),
+                ],
+                error: $("Sorry we don't recognise that reply. " + 
+                "Please enter the number next to your answer.")
+            });
+        });
+
+        self.add("state_no_channel_switch", function (name) {
+            var contact = self.im.user.answers.contact;
+            return new MenuState(name, {
+              question: $(
+                "You'll keep getting your messages on {{channel}}. If you change your mind, " +
+                "dial *134*550*9#. What would you like to do?"
+              ).context({ channel: self.contact_current_channel(contact) }),
+              choices: [
+                new Choice("state_start", $("Back to main menu")),
+                new Choice("state_exit", $("Exit"))
+              ],
+              error: $("Sorry we don't recognise that reply. " + 
+                "Please enter the number next to your answer.")
+            });
+        });
+
+        self.add("state_supporter_channel_switch_rapidpro", function (name, opts) {
+            var contact = self.im.user.answers.contact, flow_uuid;
+            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
+              flow_uuid = self.im.config.sms_switch_flow_uuid;
+            } else {
+              flow_uuid = self.im.config.whatsapp_switch_flow_uuid;
+            }
+            var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      
+            return self.rapidpro
+              .start_flow(flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"))
+              .then(function () {
+                return self.states.create("state_supporter_channel_switch_success");
+              }).catch(function (e) {
+                // Go to error state after 3 failed HTTP requests
+                opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+                if (opts.http_error_count === 3) {
+                  self.im.log.error(e.message);
+                  return self.states.create("__error__", { return_state: name });
+                }
+                return self.states.create(name, opts);
+              });
+        });
+
+        self.add("state_supporter_channel_switch_success", function (name) {
+            var contact = self.im.user.answers.contact;
+            return new MenuState(name, {
+              question: $(
+                "Okay. I'll send you MomConnect messages on {{alternative_channel}}. " +
+                "To move back to {{current_channel}}, dial *134*550*9#."
+              ).context({
+                alternative_channel: self.contact_alternative_channel(contact),
+                current_channel: self.contact_current_channel(contact)
+              }),
+              choices: [
+                new Choice("state_supporter_profile", $("Back")),
+                new Choice("state_exit", $("Exit"))
+              ],
+              error: $(
+                "Sorry we don't recognise that reply. Please enter the number next to your " +
+                "answer."
+              )
+            });
+          });
 
         self.add("state_supporter_new_research_consent", function(name) {
             return new ChoiceState(name, {

--- a/src/ussd_mcgcc_rapidpro.js
+++ b/src/ussd_mcgcc_rapidpro.js
@@ -730,7 +730,7 @@ go.app = function() {
                 ]
             });
         });
-        
+
         self.add('state_supporter_change_info', function(name) {
             var contact = self.im.user.answers.contact;
             if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
@@ -867,8 +867,6 @@ go.app = function() {
                 next: "state_supporter_change_language_rapidpro"
             });
         });
-
-
 
         self.add("state_supporter_new_language_sms", function(name) {
             return new ChoiceState(name, {

--- a/src/ussd_mcgcc_rapidpro.js
+++ b/src/ussd_mcgcc_rapidpro.js
@@ -732,7 +732,6 @@ go.app = function() {
         });
 
         self.add('state_supporter_change_info', function(name) {
-            var contact = self.im.user.answers.contact;
             return new MenuState(name, {
                 question: $(
                     "What would you like to change?"),
@@ -743,11 +742,6 @@ go.app = function() {
                     new Choice("state_supporter_new_name", $("Name")),
                     new Choice("state_supporter_new_language_whatsapp", $("Language")),
                     new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact),
-                        })),
                     new Choice("state_supporter_new_research_consent", $("Research Consent")),
                     new Choice("state_supporter_profile", $("Back"))
                 ]
@@ -1056,83 +1050,6 @@ go.app = function() {
                 }),
             });
         });
-
-        self.add("state_supporter_channel_switch_confirm", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-                question: $("Are you sure you want to get your MomConnect messages on " +
-                "{{alternative_channel}}?").context({
-                    alternative_channel: self.contact_alternative_channel(contact)
-                }),
-                choices: [
-                    new Choice("state_supporter_channel_switch_rapidpro", $("Yes")),
-                    new Choice("state_no_channel_switch", $("No")),
-                ],
-                error: $("Sorry we don't recognise that reply. " + 
-                "Please enter the number next to your answer.")
-            });
-        });
-
-        self.add("state_no_channel_switch", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-              question: $(
-                "You'll keep getting your messages on {{channel}}. If you change your mind, " +
-                "dial *134*550*9#. What would you like to do?"
-              ).context({ channel: self.contact_current_channel(contact) }),
-              choices: [
-                new Choice("state_start", $("Back to main menu")),
-                new Choice("state_exit", $("Exit"))
-              ],
-              error: $("Sorry we don't recognise that reply. " + 
-                "Please enter the number next to your answer.")
-            });
-        });
-
-        self.add("state_supporter_channel_switch_rapidpro", function (name, opts) {
-            var contact = self.im.user.answers.contact, flow_uuid;
-            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
-              flow_uuid = self.im.config.sms_switch_flow_uuid;
-            } else {
-              flow_uuid = self.im.config.whatsapp_switch_flow_uuid;
-            }
-            var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
-      
-            return self.rapidpro
-              .start_flow(flow_uuid, null, "whatsapp:" + _.trim(msisdn, "+"))
-              .then(function () {
-                return self.states.create("state_supporter_channel_switch_success");
-              }).catch(function (e) {
-                // Go to error state after 3 failed HTTP requests
-                opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
-                if (opts.http_error_count === 3) {
-                  self.im.log.error(e.message);
-                  return self.states.create("__error__", { return_state: name });
-                }
-                return self.states.create(name, opts);
-              });
-        });
-
-        self.add("state_supporter_channel_switch_success", function (name) {
-            var contact = self.im.user.answers.contact;
-            return new MenuState(name, {
-              question: $(
-                "Okay. I'll send you MomConnect messages on {{alternative_channel}}. " +
-                "To move back to {{current_channel}}, dial *134*550*9#."
-              ).context({
-                alternative_channel: self.contact_alternative_channel(contact),
-                current_channel: self.contact_current_channel(contact)
-              }),
-              choices: [
-                new Choice("state_supporter_profile", $("Back")),
-                new Choice("state_exit", $("Exit"))
-              ],
-              error: $(
-                "Sorry we don't recognise that reply. Please enter the number next to your " +
-                "answer."
-              )
-            });
-          });
 
         self.add("state_supporter_new_research_consent", function(name) {
             return new ChoiceState(name, {

--- a/src/ussd_mcgcc_rapidpro.js
+++ b/src/ussd_mcgcc_rapidpro.js
@@ -733,44 +733,30 @@ go.app = function() {
 
         self.add('state_supporter_change_info', function(name) {
             var contact = self.im.user.answers.contact;
-            if (_.toUpper(_.get(contact, "fields.preferred_channel")) === "WHATSAPP") {
-                return self.states.create("state_supporter_change_info_WA");
-              }
+            var choices = [
+                new Choice("state_supporter_new_name", $("Name")),
+                new Choice("state_supporter_new_language_whatsapp", $("Language")),
+                new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
+                
+                new Choice("state_supporter_channel_switch_confirm",
+                    $("Change from {{current_channel}} to {{alternative_channel}}").context({
+                        current_channel: self.contact_current_channel(contact),
+                        alternative_channel: self.contact_alternative_channel(contact),
+                    })),
+                new Choice("state_supporter_new_research_consent", $("Research Consent")),
+                new Choice("state_supporter_profile", $("Back"))
+            ];
+            var preferred_channel = (_.toUpper(_.get(contact, "fields.preferred_channel")));
+            if (preferred_channel === "WHATSAPP"){
+                choices.splice(3,1);
+            }
             return new MenuState(name, {
                 question: $(
                     "What would you like to change?"),
                 error: $(
                     "Please try again. Reply with the nr that matches your answer."),
                 accept_labels: true,
-                choices: [
-                    new Choice("state_supporter_new_name", $("Name")),
-                    new Choice("state_supporter_new_language_whatsapp", $("Language")),
-                    new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_channel_switch_confirm",
-                        $("Change from {{current_channel}} to {{alternative_channel}}").context({
-                            current_channel: self.contact_current_channel(contact),
-                            alternative_channel: self.contact_alternative_channel(contact),
-                        })),
-                    new Choice("state_supporter_new_research_consent", $("Research Consent")),
-                    new Choice("state_supporter_profile", $("Back"))
-                ]
-            });
-        });
-
-        self.add('state_supporter_change_info_WA', function(name) {
-            return new MenuState(name, {
-                question: $(
-                    "What would you like to change?"),
-                error: $(
-                    "Please try again. Reply with the nr that matches your answer."),
-                accept_labels: true,
-                choices: [
-                    new Choice("state_supporter_new_name", $("Name")),
-                    new Choice("state_supporter_new_language_whatsapp", $("Language")),
-                    new Choice("state_supporter_new_msisdn", $("Cellphone Number")),
-                    new Choice("state_supporter_new_research_consent", $("Research Consent")),
-                    new Choice("state_supporter_profile", $("Back"))
-                ]
+                choices: choices
             });
         });
 

--- a/test/ussd_mcgcc_rapidpro.test.js
+++ b/test/ussd_mcgcc_rapidpro.test.js
@@ -922,7 +922,7 @@ describe("ussd_mcgcc app", function() {
                 })
                 .input("2")
                 .check.interaction({
-                    state: "state_supporter_change_info_WA",
+                    state: "state_supporter_change_info",
                     reply: [
                         "What would you like to change?",
                         "1. Name",

--- a/test/ussd_mcgcc_rapidpro.test.js
+++ b/test/ussd_mcgcc_rapidpro.test.js
@@ -928,9 +928,8 @@ describe("ussd_mcgcc app", function() {
                         "1. Name",
                         "2. Language",
                         "3. Cellphone Number",
-                        "4. Change from WhatsApp to SMS",
-                        "5. Research Consent",
-                        "6. Back"
+                        "4. Research Consent",
+                        "5. Back"
                     ].join("\n")
                 })
                 .run();
@@ -1230,67 +1229,10 @@ describe("ussd_mcgcc app", function() {
                 })
                 .run();
         });
-        it("should ask the user if they want to switch channels", function() {
-            return tester
-              .setup.user.state("state_supporter_channel_switch_confirm")
-              .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
-              .check.interaction({
-                reply: [
-                  "Are you sure you want to get your MomConnect messages on WhatsApp?",
-                  "1. Yes",
-                  "2. No"
-                ].join("\n")
-              })
-              .run();
-          });
-          it("should show the user an error on invalid input", function() {
-            return tester
-              .setup.user.state("state_supporter_channel_switch_confirm")
-              .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
-              .input("A")
-              .check.interaction({
-                reply: [
-                  "Sorry we don't recognise that reply. Please enter the number next to " +
-                  "your answer.",
-                  "1. Yes",
-                  "2. No"
-                ].join("\n")
-              })
-              .run();
-          });
-          it("should submit the channel switch if they choose yes", function() {
-            return tester
-              .setup.user.state("state_supporter_channel_switch_confirm")
-              .setup.user.answer("contact", {fields: {preferred_channel: "SMS"}})
-              .setup(function(api) {
-                api.http.fixtures.add(
-                  fixtures_rapidpro.start_flow(
-                    "whatsapp-switch-flow-uuid", null, "whatsapp:27123456789"
-                  )
-                );
-              })
-              .input("1")
-              .check.interaction({
-                reply: [
-                  "Okay. I'll send you MomConnect messages on WhatsApp. " +
-                  "To move back to SMS, dial *134*550*9#.",
-                  "1. Back",
-                  "2. Exit"
-                ].join("\n"),
-                state: "state_supporter_channel_switch_success"
-                })
-                .check(function(api) {
-                assert.equal(api.http.requests.length, 1);
-                assert.equal(
-                api.http.requests[0].url, "https://rapidpro/api/v2/flow_starts.json"
-                );
-              })
-              .run();
-          }); 
         it("should ask for research consent", function() {
             return tester.setup.user
                 .state("state_supporter_change_info")
-                .input("5")
+                .input("4")
                 .check.interaction({
                     state: "state_supporter_new_research_consent",
                     reply: [


### PR DESCRIPTION
This pr has two commits. 
The first one removes the "change channel" option from the menu but we realized that we need to keep it in to allow contacts on SMS switch over to Whatsapp. 

The second pr replaces the "change channel" option but makes sure it's only visible to contacts on SMS. 
Contacts on Whatsapp never get to see it.