### PR TITLE
Prebirth <42 weeks should start the prebirth flow and edd value shoul…

### DIFF
--- a/go-app-ussd_clinic_rapidpro.js
+++ b/go-app-ussd_clinic_rapidpro.js
@@ -508,7 +508,7 @@ go.app = function() {
             };
 
             var subscriptions = [];
-            if (!(isNaN(edd)) ){
+            if (!(isNaN(edd))) {
                 subscriptions.push("baby due on {{edd}}");
                 context.edd = edd.format("DD/MM/YYYY");
             }

--- a/go-app-ussd_clinic_rapidpro.js
+++ b/go-app-ussd_clinic_rapidpro.js
@@ -501,14 +501,14 @@ go.app = function() {
             var msisdn = utils.readable_msisdn(
                 _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr), "27");
             var contact = self.im.user.answers.contact;
-            var edd = self.contact_edd(contact);
+            var edd = new moment(_.get(contact, "fields.edd", null));
             var dobs = self.contact_postbirth_dobs(contact);
             var context = {
                 msisdn: msisdn
             };
 
             var subscriptions = [];
-            if (edd) {
+            if (!(isNaN(edd)) ){
                 subscriptions.push("baby due on {{edd}}");
                 context.edd = edd.format("DD/MM/YYYY");
             }
@@ -1246,7 +1246,9 @@ go.app = function() {
                 swt: "7"
             };
             var flow_uuid;
-            if (self.im.user.answers.state_message_type === "state_edd_month") {
+            
+            if (self.im.user.answers.state_message_type === "state_edd_month" 
+                || typeof self.im.user.answers.state_edd_month != "undefined") {   
                 flow_uuid = self.im.config.prebirth_flow_uuid;
                 data.edd = new moment.utc(
                     self.im.user.answers.state_edd_month +

--- a/src/ussd_clinic_rapidpro.js
+++ b/src/ussd_clinic_rapidpro.js
@@ -263,14 +263,14 @@ go.app = function() {
             var msisdn = utils.readable_msisdn(
                 _.get(self.im.user.answers, "state_enter_msisdn", self.im.user.addr), "27");
             var contact = self.im.user.answers.contact;
-            var edd = self.contact_edd(contact);
+            var edd = new moment(_.get(contact, "fields.edd", null));
             var dobs = self.contact_postbirth_dobs(contact);
             var context = {
                 msisdn: msisdn
             };
 
             var subscriptions = [];
-            if (edd) {
+            if (!(isNaN(edd)) ){
                 subscriptions.push("baby due on {{edd}}");
                 context.edd = edd.format("DD/MM/YYYY");
             }
@@ -1008,7 +1008,9 @@ go.app = function() {
                 swt: "7"
             };
             var flow_uuid;
-            if (self.im.user.answers.state_message_type === "state_edd_month") {
+            
+            if (self.im.user.answers.state_message_type === "state_edd_month" 
+                || typeof self.im.user.answers.state_edd_month != "undefined") {   
                 flow_uuid = self.im.config.prebirth_flow_uuid;
                 data.edd = new moment.utc(
                     self.im.user.answers.state_edd_month +

--- a/src/ussd_clinic_rapidpro.js
+++ b/src/ussd_clinic_rapidpro.js
@@ -270,7 +270,7 @@ go.app = function() {
             };
 
             var subscriptions = [];
-            if (!(isNaN(edd)) ){
+            if (!(isNaN(edd))) {
                 subscriptions.push("baby due on {{edd}}");
                 context.edd = edd.format("DD/MM/YYYY");
             }


### PR DESCRIPTION
…d be displayed correctly

Because a new prebirth registration skips state_message_type if EDD > 42 weeks, contacts in this category enter details for pre-birth but are started on the post-birth flow.

Secondly, the helper function ony returns EDD if EDD < 42 weeks so if greater and a contact has the condition above we send a message with an empty EDD such as "The number 0827081992 is already receiving messages from MomConnect for....."