### PR TITLE
Move the check EDD field check from EDD month to EDD year state

### DIFF
--- a/go-app-ussd_clinic_rapidpro.js
+++ b/go-app-ussd_clinic_rapidpro.js
@@ -639,6 +639,10 @@ go.app = function() {
         });
 
         self.add("state_edd_year", function(name) {
+            var contact = self.im.user.answers.contact;
+            if (self.contact_edd(contact)) {
+                return self.states.create("state_active_prebirth_end");
+            }
             var today = new moment(self.im.config.testing_today).startOf("day");
             var choices = _.map(
                 // For this year and next year, we need 2 options
@@ -666,10 +670,6 @@ go.app = function() {
         });
 
         self.add("state_edd_month", function(name) {
-            var contact = self.im.user.answers.contact;
-            if (self.contact_edd(contact)) {
-                return self.states.create("state_active_prebirth_end");
-            }
             var today = new moment(self.im.config.testing_today).startOf("day");
             var start_date = today.clone().add(1, "days");
             var end_date = today.clone().add(52, "weeks").add(-1, "days");

--- a/src/ussd_clinic_rapidpro.js
+++ b/src/ussd_clinic_rapidpro.js
@@ -401,6 +401,10 @@ go.app = function() {
         });
 
         self.add("state_edd_year", function(name) {
+            var contact = self.im.user.answers.contact;
+            if (self.contact_edd(contact)) {
+                return self.states.create("state_active_prebirth_end");
+            }
             var today = new moment(self.im.config.testing_today).startOf("day");
             var choices = _.map(
                 // For this year and next year, we need 2 options
@@ -428,10 +432,6 @@ go.app = function() {
         });
 
         self.add("state_edd_month", function(name) {
-            var contact = self.im.user.answers.contact;
-            if (self.contact_edd(contact)) {
-                return self.states.create("state_active_prebirth_end");
-            }
             var today = new moment(self.im.config.testing_today).startOf("day");
             var start_date = today.clone().add(1, "days");
             var end_date = today.clone().add(52, "weeks").add(-1, "days");

--- a/test/ussd_clinic_rapidpro.test.js
+++ b/test/ussd_clinic_rapidpro.test.js
@@ -278,7 +278,7 @@ describe("ussd_clinic app", function() {
     describe("state_active_subscription", function() {
         it("should display the end screen for active prebirth", function() {
             return tester
-                .setup.user.state("state_edd_month")
+                .setup.user.state("state_edd_year")
                 .setup.user.answer("contact", {fields: {edd: "2014-09-10"}})
                 .check.interaction({
                     state: "state_active_prebirth_end",


### PR DESCRIPTION
This change does not affect functionality but improves user experience. 

Currently, if EDD is active and <42 weeks we inform them but let them enter EDD year for new registration before telling them that they have to optout first. They do not need to enter EDD year before we display the end screen on how to opt-out from an existing prebirth.