### PR TITLE
Option 3 should switch control to FAQ state

### DIFF
--- a/go-app-ussd_tb_check.js
+++ b/go-app-ussd_tb_check.js
@@ -1,52 +1,6 @@
 var go = {};
 go;
 
-go.Engage = function() {
-    var vumigo = require('vumigo_v02');
-    var events = vumigo.events;
-    var Eventable = events.Eventable;
-    var _ = require('lodash');
-    var url = require('url');
-
-    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
-        self.json_api = json_api;
-        self.base_url = base_url;
-        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
-        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
-
-        self.contact_check = function(msisdn, block) {
-            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
-                data: {
-                    blocking: block ? 'wait' : 'no_wait',
-                    contacts: [msisdn]
-                }
-            }).then(function(response) {
-                var existing = _.filter(response.data.contacts, function(obj) {
-                    return obj.status === "valid";
-                });
-                return !_.isEmpty(existing);
-            });
-        };
-
-          self.LANG_MAP = {zul_ZA: "en",
-                          xho_ZA: "en",
-                          afr_ZA: "af",
-                          eng_ZA: "en",
-                          nso_ZA: "en",
-                          tsn_ZA: "en",
-                          sot_ZA: "en",
-                          tso_ZA: "en",
-                          ssw_ZA: "en",
-                          ven_ZA: "en",
-                          nbl_ZA: "en",
-                        };
-    });
-
-
-
-    return Engage;
-}();
-
 go.RapidPro = function() {
     var vumigo = require('vumigo_v02');
     var url_utils = require('url');
@@ -485,7 +439,7 @@ go.app = function () {
           choices: [
               new Choice("state_gender", $("Yes")),
               new Choice("state_research_consent_no", $("No")),
-              new Choice("state_send_faq_sms", $("FAQ for more info on TBCheck and the research.")),
+              new Choice("state_faq", $("FAQ for more info on TBCheck and the research.")),
           ],
       });
   });

--- a/go-app-ussd_tb_check.js
+++ b/go-app-ussd_tb_check.js
@@ -1,6 +1,52 @@
 var go = {};
 go;
 
+go.Engage = function() {
+    var vumigo = require('vumigo_v02');
+    var events = vumigo.events;
+    var Eventable = events.Eventable;
+    var _ = require('lodash');
+    var url = require('url');
+
+    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
+        self.json_api = json_api;
+        self.base_url = base_url;
+        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
+        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
+
+        self.contact_check = function(msisdn, block) {
+            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
+                data: {
+                    blocking: block ? 'wait' : 'no_wait',
+                    contacts: [msisdn]
+                }
+            }).then(function(response) {
+                var existing = _.filter(response.data.contacts, function(obj) {
+                    return obj.status === "valid";
+                });
+                return !_.isEmpty(existing);
+            });
+        };
+
+          self.LANG_MAP = {zul_ZA: "en",
+                          xho_ZA: "en",
+                          afr_ZA: "af",
+                          eng_ZA: "en",
+                          nso_ZA: "en",
+                          tsn_ZA: "en",
+                          sot_ZA: "en",
+                          tso_ZA: "en",
+                          ssw_ZA: "en",
+                          ven_ZA: "en",
+                          nbl_ZA: "en",
+                        };
+    });
+
+
+
+    return Engage;
+}();
+
 go.RapidPro = function() {
     var vumigo = require('vumigo_v02');
     var url_utils = require('url');

--- a/src/ussd_tb_check.js
+++ b/src/ussd_tb_check.js
@@ -336,7 +336,7 @@ go.app = function () {
           choices: [
               new Choice("state_gender", $("Yes")),
               new Choice("state_research_consent_no", $("No")),
-              new Choice("state_send_faq_sms", $("FAQ for more info on TBCheck and the research.")),
+              new Choice("state_faq", $("FAQ for more info on TBCheck and the research.")),
           ],
       });
   });


### PR DESCRIPTION
When the contact selects option 3 on the research_consent screen (FAQ option) we should switch to the FAQ menu state before the FAQ send_sms state otherwise there will be no label for the flow below and the contact won't get an sms. 

https://healthcheck-rapidpro.covid19-k8s.prd-p6t.org/flow/editor/78a76017-2684-4ebb-bcd8-7b3e70fa8eea/