### PR TITLE
Not skip street and suburb for users who want to change it

### DIFF
--- a/go-app-ussd_tb_check.js
+++ b/go-app-ussd_tb_check.js
@@ -613,10 +613,14 @@ go.app = function () {
     });
 
     self.add("state_street_name", function (name) {
-      if (self.im.user.answers.state_street_name &&
-        self.im.user.answers.state_suburb_name) {
-      return self.states.create("state_city");
-    }
+      if ((_.toUpper(self.im.user.answers.state_confirm_city)) != "NO")
+      {
+        if (self.im.user.answers.state_street_name &&
+          self.im.user.answers.state_suburb_name) {
+        return self.states.create("state_city");
+        }
+      }
+      
       var question = $(
         "Please type the name of the street where you live."
       );
@@ -633,9 +637,13 @@ go.app = function () {
     });
 
     self.add("state_suburb_name", function (name) {
-      if (self.im.user.answers.state_suburb_name) {
-        return self.states.create("state_city");
+      if (self.im.user.answers.state_confirm_city != "No")
+      {
+        if (self.im.user.answers.state_suburb_name) {
+          return self.states.create("state_city");
+        }
       }
+      
       var question = $(
         "Please type the name of the suburb/township/village where you live."
       );

--- a/src/ussd_tb_check.js
+++ b/src/ussd_tb_check.js
@@ -464,10 +464,14 @@ go.app = function () {
     });
 
     self.add("state_street_name", function (name) {
-      if (self.im.user.answers.state_street_name &&
-        self.im.user.answers.state_suburb_name) {
-      return self.states.create("state_city");
-    }
+      if ((_.toUpper(self.im.user.answers.state_confirm_city)) != "NO")
+      {
+        if (self.im.user.answers.state_street_name &&
+          self.im.user.answers.state_suburb_name) {
+        return self.states.create("state_city");
+        }
+      }
+      
       var question = $(
         "Please type the name of the street where you live."
       );
@@ -484,9 +488,13 @@ go.app = function () {
     });
 
     self.add("state_suburb_name", function (name) {
-      if (self.im.user.answers.state_suburb_name) {
-        return self.states.create("state_city");
+      if (self.im.user.answers.state_confirm_city != "No")
+      {
+        if (self.im.user.answers.state_suburb_name) {
+          return self.states.create("state_city");
+        }
       }
+      
       var question = $(
         "Please type the name of the suburb/township/village where you live."
       );

--- a/test/ussd_tb_check.test.js
+++ b/test/ussd_tb_check.test.js
@@ -1069,6 +1069,24 @@ describe("ussd_tb_check app", function () {
         .check.user.state("state_city")
         .run();
     });
+    it("should not skip street name for users who want to change it", function () {
+      return tester.setup.user
+        .state("state_street_name")
+        .setup.user.answer("state_street_name", "7 soteba str")
+        .setup.user.answer("state_suburb_name", "Soweto")
+        .setup.user.answer("state_confirm_city", "No")
+        .check.user.state("state_street_name")
+        .run();
+    });
+    it("should not skip suburb name for users who want to change it", function () {
+      return tester.setup.user
+        .state("state_suburb_name")
+        .setup.user.answer("state_street_name", "7 soteba str")
+        .setup.user.answer("state_suburb_name", "Soweto")
+        .setup.user.answer("state_confirm_city", "No")
+        .check.user.state("state_suburb_name")
+        .run();
+    });
   describe("state_confirm_city", function () {
     it("should ask to confirm the city", function () {
       return tester.setup.user


### PR DESCRIPTION
At state_confirm_address if a user replies "No", they can only change the city but no the suburb or street because we only check if it exists and then skip if TRUE.