### PR TITLE
Use prebirth messaging field to check for prebirth instead of edd field

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -44,53 +44,6 @@ go.Hub = function() {
     return Hub;
 }();
 
-go.Engage = function() {
-    var vumigo = require('vumigo_v02');
-    var events = vumigo.events;
-    var Eventable = events.Eventable;
-    var _ = require('lodash');
-    var url = require('url');
-
-    var Engage = Eventable.extend(function(self, json_api, base_url, token) {
-        self.json_api = json_api;
-        self.base_url = base_url;
-        self.json_api.defaults.headers.Authorization = ['Bearer ' + token];
-        self.json_api.defaults.headers['Content-Type'] = ['application/json'];
-
-        self.contact_check = function(msisdn, block) {
-            return self.json_api.post(url.resolve(self.base_url, 'v1/contacts'), {
-                data: {
-                    blocking: block ? 'wait' : 'no_wait',
-                    contacts: [msisdn]
-                }
-            }).then(function(response) {
-                var existing = _.filter(response.data.contacts, function(obj) {
-                    return obj.status === "valid";
-                });
-                return !_.isEmpty(existing);
-            });
-        };
-
-          self.LANG_MAP = {zul_ZA: "en",
-                          xho_ZA: "en",
-                          afr_ZA: "af",
-                          eng_ZA: "en",
-                          nso_ZA: "en",
-                          tsn_ZA: "en",
-                          sot_ZA: "en",
-                          tso_ZA: "en",
-                          ssw_ZA: "en",
-                          ven_ZA: "en",
-                          nbl_ZA: "en",
-                          set_ZA: "en",
-                        };
-    });
-
-
-
-    return Engage;
-}();
-
 go.RapidPro = function() {
     var vumigo = require('vumigo_v02');
     var url_utils = require('url');

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -373,10 +373,12 @@ go.app = function() {
         self.add("state_active_prebirth_check", function(name){
             var contact = self.im.user.answers.contact;
             var edd = new moment(_.get(contact, "fields.edd", null)).format("YYYY-MM-DD");
+            var prebirth = _.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7);
 
-            if (!self.contact_edd(contact)) {
+            if (!prebirth) {
                 return self.states.create("state_edd_change_end");
             }
+
             return new MenuState(name, {
                 question: $(
                     "You are currently receiving pregnancy messages " +
@@ -735,7 +737,7 @@ go.app = function() {
                 self.im.user.answers.state_baby_born_month +
                 self.im.user.answers.state_baby_born_day,
                 "YYYYMMDD"
-            ).format();
+            ).format('YYYY-MM-DD');
             return new MenuState(name, {
                 question: $(
                     "Your baby's date of birth has been updated to " +

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -510,7 +510,8 @@ describe("ussd_popi_rapidpro app", function() {
                     baby_dob1: "2021-03-10",
                     baby_dob2: "2021-11-11",
                     baby_dob3: "2022-03-07",
-                    edd: "2022-06-06"
+                    edd: "2022-06-06",
+                    prebirth_messaging: "1"
                 },
                 })
                 .input("3")
@@ -530,7 +531,8 @@ describe("ussd_popi_rapidpro app", function() {
             return tester
                 .setup.user.state("state_active_prebirth_check")
                 .setup.user.answer("contact", {fields: {
-                    edd: "2022-06-06T00:00:00Z"
+                    edd: "2022-06-06T00:00:00Z",
+                    prebirth_messaging: "1"
                 },
                 })
                 .input("1")
@@ -694,6 +696,15 @@ describe("ussd_popi_rapidpro app", function() {
                 })
                 .input("1")
                 .check.user.state("state_baby_born_complete")
+                .check.interaction({
+                    reply: [
+                        "Your baby's date of birth has been updated " + 
+                        "to 2022-04-04 and you will start receiving " +
+                        "messages based on this schedule.",
+                        "1. Back",
+                        "2. Exit"
+                    ].join("\n")
+                })
                 .run();
         });
 
@@ -705,7 +716,8 @@ describe("ussd_popi_rapidpro app", function() {
             return tester
                 .setup.user.state("state_active_prebirth_check")
                 .setup.user.answer("contact", {fields: {
-                    edd: "2022-06-06T00:00:00Z"
+                    edd: "2022-06-06T00:00:00Z",
+                    prebirth_messaging: "1"
                 },
                 })
                 .input("2")


### PR DESCRIPTION
- Use prebirth messaging field to check for prebirth instead of the EDD date field.
     This is necesary because we do not clear EDD when we do a baby switch from prebirth to postbirth.

- Also the EDD siwtch confirmation message shows the new EDD as Datetime where as we only want to see the date.