### PR TITLE
Add new_wa_id to msisdn change

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -2369,13 +2369,15 @@ go.app = function() {
             var old_msisdn = utils.normalize_msisdn(
                 self.im.user.answers.state_enter_origin_msisdn, "ZA"
             );
+            var new_wa_id = "whatsapp:" + _.trim(new_msisdn, "+");
             return self.rapidpro
                 .start_flow(
                     self.im.config.msisdn_change_flow_id, null, "whatsapp:" + _.trim(new_msisdn, "+"), {
                         new_msisdn: new_msisdn,
                         old_msisdn: old_msisdn,
                         contact_uuid: self.im.user.answers.origin_contact.uuid,
-                        source: "POPI USSD"
+                        source: "POPI USSD",
+                        new_wa_id: new_wa_id
                     }
                 )
                 .then(function() {

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -2223,13 +2223,15 @@ go.app = function() {
             var old_msisdn = utils.normalize_msisdn(
                 self.im.user.answers.state_enter_origin_msisdn, "ZA"
             );
+            var new_wa_id = "whatsapp:" + _.trim(new_msisdn, "+");
             return self.rapidpro
                 .start_flow(
                     self.im.config.msisdn_change_flow_id, null, "whatsapp:" + _.trim(new_msisdn, "+"), {
                         new_msisdn: new_msisdn,
                         old_msisdn: old_msisdn,
                         contact_uuid: self.im.user.answers.origin_contact.uuid,
-                        source: "POPI USSD"
+                        source: "POPI USSD",
+                        new_wa_id: new_wa_id
                     }
                 )
                 .then(function() {

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -2518,7 +2518,8 @@ describe("ussd_popi_rapidpro app", function() {
                                 new_msisdn: "+27123456789",
                                 old_msisdn: "+27820001002",
                                 contact_uuid: "contact-uuid",
-                                source: "POPI USSD"
+                                source: "POPI USSD",
+                                new_wa_id: "whatsapp:27123456789"
                             }
                         )
                     );


### PR DESCRIPTION
Contacts who go through the nosim_msisdn_change route would not have the new_wa_id sent to Rapidpro.
It wasn't part of the payload even though the RP flow expects it. 

This pr adds it to the list so it gets sent to RP.