### PR TITLE
Exclude EDD from menu option if contact in Postbirth

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -440,7 +440,7 @@ go.app = function() {
 
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
-            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd;
+            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd, postbirth;
             var dates_list = [];
             var channel = _.get(contact, "fields.preferred_channel");
             var context = {
@@ -467,6 +467,7 @@ go.app = function() {
                 new Choice("state_change_research_confirm", $("Research msgs")),
                 new Choice("state_main_menu", $("Back"))
             ];
+            postbirth = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
 
             if (dates_entry[0].length){
                 dates_list = dates_entry[0].trim().split(/\s*,\s*/);
@@ -510,7 +511,11 @@ go.app = function() {
 
             function push_dob(channel_list, dob_list, dob_count)
             {
-                for (var i = 0; i < (dob_count); i++) {
+                var i = 0;
+                if (postbirth){
+                    ++i;
+                }
+                for (i; i < (dob_count); i++) {
                     channel_list.splice(i+2, 0, dob_list[i]);
                 }
 
@@ -520,7 +525,7 @@ go.app = function() {
                 accept_labels: true,
                 options_per_page: null,
                 characters_per_page: 160,
-                error: $("Sorry we don't understand. Pls try again."),
+                error: $("We don't understand. Please try again."),
                 choices: channel == "WhatsApp" ? whatsapp_choices : sms_choices,
                 more: $("Next"),
                 back: $("Previous"),

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -280,7 +280,7 @@ go.app = function() {
 
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
-            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd;
+            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd, postbirth;
             var dates_list = [];
             var channel = _.get(contact, "fields.preferred_channel");
             var context = {
@@ -307,6 +307,7 @@ go.app = function() {
                 new Choice("state_change_research_confirm", $("Research msgs")),
                 new Choice("state_main_menu", $("Back"))
             ];
+            postbirth = _.toUpper(_.get(contact, "fields.postbirth_messaging")) === "TRUE";
 
             if (dates_entry[0].length){
                 dates_list = dates_entry[0].trim().split(/\s*,\s*/);
@@ -350,7 +351,11 @@ go.app = function() {
 
             function push_dob(channel_list, dob_list, dob_count)
             {
-                for (var i = 0; i < (dob_count); i++) {
+                var i = 0;
+                if (postbirth){
+                    ++i;
+                }
+                for (i; i < (dob_count); i++) {
                     channel_list.splice(i+2, 0, dob_list[i]);
                 }
 
@@ -360,7 +365,7 @@ go.app = function() {
                 accept_labels: true,
                 options_per_page: null,
                 characters_per_page: 160,
-                error: $("Sorry we don't understand. Pls try again."),
+                error: $("We don't understand. Please try again."),
                 choices: channel == "WhatsApp" ? whatsapp_choices : sms_choices,
                 more: $("Next"),
                 back: $("Previous"),

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -439,6 +439,53 @@ describe("ussd_popi_rapidpro app", function() {
                 })
                 .run();
         });
+        it("should display the list of options to the user SMS page 2 with EDD and postbirth", function() {
+            return tester
+                .setup.user.state("state_change_info")
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS",
+                    baby_dob1: "2021-03-10",
+                    baby_dob2: "2021-11-11",
+                    baby_dob3: "2022-07-07",
+                    edd: "2020-06-04",
+                    postbirth_messaging: "True"
+                },
+                })
+                .input("6")
+                .check.interaction({
+                    reply: [
+                        "What would you like to change?",
+                        "1. 3rd Baby's DoB: 07-07-2022",
+                        "2. ID",
+                        "3. Research msgs",
+                        "4. Back",
+                        "5. Previous"
+                    ].join("\n")
+                })
+                .run();
+        });
+        it("should display the list of options to the user SMS page 1 with EDD and postbirth", function() {
+            return tester
+                .setup.user.state("state_change_info")
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS",
+                    baby_dob1: "2021-03-10",
+                    baby_dob2: "2021-11-11",
+                    baby_dob3: "2022-07-07",
+                    edd: "2020-06-04",
+                    postbirth_messaging: "True"
+                }})
+                .check.interaction({
+                    reply: [
+                        "What would you like to change?",
+                        "1. Cell number",
+                        "2. Change SMS to WhatsApp",
+                        "3. Language",
+                        "4. 1st Baby's DoB: 10-03-2021",
+                        "5. 2nd Baby's DoB: 11-11-2021",
+                        "6. Next"
+                    ].join("\n")
+                })
+                .run();
+        });
         it("should display the list of options to the user WhatsApp page 1", function() {
             return tester
                 .setup.user.state("state_change_info")
@@ -881,19 +928,43 @@ describe("ussd_popi_rapidpro app", function() {
                 .check.user.state("state_edd_baby_unborn_complete")
                 .run();
         });
-        it("should display an error on invalid input", function() {
+        it("should display an error on invalid input and should not show EDD if contact has postbirth messaging", function() {
             return tester
                 .setup.user.state("state_change_info")
                 .setup.user.answer("contact", {fields: {preferred_channel: "SMS",
                     baby_dob1: "2021-03-10",
                     baby_dob2: "2021-11-11",
                     baby_dob3: "2022-07-07",
-                    edd: "2020-06-04"
+                    edd: "2020-06-04",
+                    postbirth_messaging: "True"
                 }})
                 .input("A")
                 .check.interaction({
                     reply: [
-                        "Sorry we don't understand. Pls try again.",
+                        "We don't understand. Please try again.",
+                        "1. Cell number",
+                        "2. Change SMS to WhatsApp",
+                        "3. Language",
+                        "4. 1st Baby's DoB: 10-03-2021",
+                        "5. 2nd Baby's DoB: 11-11-2021",
+                        "6. Next"
+                    ].join("\n")
+                })
+                .run();
+        });
+        it("should display an error on invalid input and should show EDD if contact has no postbirth messaging", function() {
+            return tester
+                .setup.user.state("state_change_info")
+                .setup.user.answer("contact", {fields: {preferred_channel: "SMS",
+                    baby_dob1: "2021-03-10",
+                    baby_dob2: "2021-11-11",
+                    baby_dob3: "2022-07-07",
+                    edd: "2020-06-04",
+                }})
+                .input("A")
+                .check.interaction({
+                    reply: [
+                        "We don't understand. Please try again.",
                         "1. Cell number",
                         "2. Change SMS to WhatsApp",
                         "3. Baby's Expected Due Date: 04-06-2020",


### PR DESCRIPTION
When a user chooses to change their details, we return a list of options with the fields they have on their contact.
Ex, 
```
"What would you like to change?
"1. Cell number",
 "2. Change SMS to WhatsApp",
 "3. EDD 09-09-2023
 "4. Language",
 "5. 1st Baby's DoB: 10-03-2021",
"6. 2nd Baby's DoB: 11-11-2021",
 "7. Next"
```
 
Because historically we do not clear the EDD field, a contact who has switched to Postbirth will still see the EDD choice even though they're now on Postbirth.

This PR checks if the contact is now receiving postbirth messages and if true it skips the EDD change option and does not display it to the user. 

The menu now looks like this: 
```
"What would you like to change?",
 "1. Cell number",
 "2. Change SMS to WhatsApp",
 "3. Language",
 "4. 1st Baby's DoB: 10-03-2021",
 "5. 2nd Baby's DoB: 11-11-2021",
  "6. Next"
```
