### PR TITLE
Dob and edd format

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -246,6 +246,11 @@ go.app = function() {
             });
         };
 
+        self.dateformat = function(timestamp){
+            timestamp = (timestamp) ? timestamp.split('T')[0] : timestamp;
+            return timestamp;
+        };
+
         self.states.add("state_start", function(name, opts) {
             // Reset user answers when restarting the app
             self.im.user.answers = {};
@@ -449,15 +454,23 @@ go.app = function() {
 
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
-            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd, postbirth;
+            var dates_count, postbirth;
             var dates_list = [];
             var channel = _.get(contact, "fields.preferred_channel");
+            var baby_dob1 = _.get(contact, "fields.baby_dob1", null);
+            var baby_dob2 = _.get(contact, "fields.baby_dob2", null);
+            var baby_dob3 = _.get(contact, "fields.baby_dob3", null);
+            var edd = _.get(contact, "fields.edd", null);
+            baby_dob1 = self.dateformat(baby_dob1);
+            baby_dob2 = self.dateformat(baby_dob2);
+            baby_dob3 = self.dateformat(baby_dob3);
+            edd = self.dateformat(edd);
             var context = {
                 dobs: _.map(_.filter([
-                    new moment(_.get(contact, "fields.edd", null)),
-                    new moment(_.get(contact, "fields.baby_dob1", null)),
-                    new moment(_.get(contact, "fields.baby_dob2", null)),
-                    new moment(_.get(contact, "fields.baby_dob3", null)),
+                    new moment(edd),
+                    new moment(baby_dob1),
+                    new moment(baby_dob2),
+                    new moment(baby_dob3),
                 ], _.method("isValid")), _.method("format", "DD-MM-YYYY")).join(", ") || $("None")
              };
             var dates_entry = Object.values(context);

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -86,6 +86,11 @@ go.app = function() {
             });
         };
 
+        self.dateformat = function(timestamp){
+            timestamp = (timestamp) ? timestamp.split('T')[0] : timestamp;
+            return timestamp;
+        };
+
         self.states.add("state_start", function(name, opts) {
             // Reset user answers when restarting the app
             self.im.user.answers = {};
@@ -289,15 +294,23 @@ go.app = function() {
 
         self.add("state_change_info", function(name) {
             var contact = self.im.user.answers.contact;
-            var baby_dob1, baby_dob2, baby_dob3, dates_count, edd, postbirth;
+            var dates_count, postbirth;
             var dates_list = [];
             var channel = _.get(contact, "fields.preferred_channel");
+            var baby_dob1 = _.get(contact, "fields.baby_dob1", null);
+            var baby_dob2 = _.get(contact, "fields.baby_dob2", null);
+            var baby_dob3 = _.get(contact, "fields.baby_dob3", null);
+            var edd = _.get(contact, "fields.edd", null);
+            baby_dob1 = self.dateformat(baby_dob1);
+            baby_dob2 = self.dateformat(baby_dob2);
+            baby_dob3 = self.dateformat(baby_dob3);
+            edd = self.dateformat(edd);
             var context = {
                 dobs: _.map(_.filter([
-                    new moment(_.get(contact, "fields.edd", null)),
-                    new moment(_.get(contact, "fields.baby_dob1", null)),
-                    new moment(_.get(contact, "fields.baby_dob2", null)),
-                    new moment(_.get(contact, "fields.baby_dob3", null)),
+                    new moment(edd),
+                    new moment(baby_dob1),
+                    new moment(baby_dob2),
+                    new moment(baby_dob3),
                 ], _.method("isValid")), _.method("format", "DD-MM-YYYY")).join(", ") || $("None")
              };
             var dates_entry = Object.values(context);

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -397,10 +397,10 @@ describe("ussd_popi_rapidpro app", function() {
             return tester
                 .setup.user.state("state_change_info")
                 .setup.user.answer("contact", {fields: {preferred_channel: "SMS",
-                    baby_dob1: "2021-03-10",
-                    baby_dob2: "2021-11-11",
-                    baby_dob3: "2022-07-07",
-                    edd: "2020-06-04",
+                    baby_dob1: "2021-03-10T00:00:00.000000Z",
+                    baby_dob2: "2021-11-11T00:00:00.000000Z",
+                    baby_dob3: "2022-07-07T00:00:00.000000Z",
+                    edd: "2020-06-04T00:00:00.000000Z",
                 }})
                 .check.interaction({
                     reply: [


### PR DESCRIPTION
Rapidpro dates are in the format YYYY-MM-DDTZ so when converted to DD-MM-YYYY the date turns into a day before.
What this does is strip away the timestamp part of the date and then convert it to DD-MM-YYYY.