### PR TITLE
EDD Date Format

### DIFF
--- a/go-app-ussd_popi_rapidpro.js
+++ b/go-app-ussd_popi_rapidpro.js
@@ -559,7 +559,7 @@ go.app = function() {
 
         self.add("state_active_prebirth_check", function(name){
             var contact = self.im.user.answers.contact;
-            var edd = new moment(_.get(contact, "fields.edd", null)).format("DD-MM-YYYY");
+            var edd = new moment(self.dateformat(_.get(contact, "fields.edd", null))).format("DD-MM-YYYY");
             var prebirth = _.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7);
 
             if (!prebirth) {

--- a/src/ussd_popi_rapidpro.js
+++ b/src/ussd_popi_rapidpro.js
@@ -399,7 +399,7 @@ go.app = function() {
 
         self.add("state_active_prebirth_check", function(name){
             var contact = self.im.user.answers.contact;
-            var edd = new moment(_.get(contact, "fields.edd", null)).format("DD-MM-YYYY");
+            var edd = new moment(self.dateformat(_.get(contact, "fields.edd", null))).format("DD-MM-YYYY");
             var prebirth = _.inRange(_.get(contact, "fields.prebirth_messaging"), 1, 7);
 
             if (!prebirth) {

--- a/test/ussd_popi_rapidpro.test.js
+++ b/test/ussd_popi_rapidpro.test.js
@@ -563,7 +563,7 @@ describe("ussd_popi_rapidpro app", function() {
                     baby_dob1: "2021-03-10",
                     baby_dob2: "2021-11-11",
                     baby_dob3: "2022-03-07",
-                    edd: "2022-06-06",
+                    edd: "2022-06-06T00:00:00Z",
                     prebirth_messaging: "1"
                 },
                 })


### PR DESCRIPTION
Rapidpro dates are in the format YYYY-MM-DDTZ so when converted to DD-MM-YYYY the date turns into a day before.
What this does is strip away the timestamp part of the date and then convert it to DD-MM-YYYY.