### PR TITLE
Rename field to pulse_survey not pulse_survey_status

### DIFF
--- a/go-app-ussd_pulse_survey_rapidpro.js
+++ b/go-app-ussd_pulse_survey_rapidpro.js
@@ -174,7 +174,7 @@ go.app = function() {
                     self.im.user.set_answer("contact", contact);
                 }).then(function() {
                     // Delegate to the correct state depending on pulse survey field              
-                    var pulse_survey_status = _.toUpper(_.get(self.im.user.get_answer("contact"), "fields.pulse_survey_status"));
+                    var pulse_survey_status = _.toUpper(_.get(self.im.user.get_answer("contact"), "fields.pulse_survey"));
                     if (pulse_survey_status === "SELECTED") {
                         return self.states.create("state_intro_message");
                         }

--- a/src/ussd_pulse_survey_rapidpro.js
+++ b/src/ussd_pulse_survey_rapidpro.js
@@ -57,7 +57,7 @@ go.app = function() {
                     self.im.user.set_answer("contact", contact);
                 }).then(function() {
                     // Delegate to the correct state depending on pulse survey field              
-                    var pulse_survey_status = _.toUpper(_.get(self.im.user.get_answer("contact"), "fields.pulse_survey_status"));
+                    var pulse_survey_status = _.toUpper(_.get(self.im.user.get_answer("contact"), "fields.pulse_survey"));
                     if (pulse_survey_status === "SELECTED") {
                         return self.states.create("state_intro_message");
                         }

--- a/test/ussd_pulse_survey_rapidpro.test.js
+++ b/test/ussd_pulse_survey_rapidpro.test.js
@@ -61,7 +61,7 @@ describe("ussd_pulse_survey app", function() {
                             urn: "whatsapp:27123456789",
                             exists: true,
                             fields: {
-                                pulse_survey_status: "SELECTED",
+                                pulse_survey: "SELECTED",
                             }
                         })
                     );
@@ -86,7 +86,7 @@ describe("ussd_pulse_survey app", function() {
                             urn: "whatsapp:27123456789",
                             exists: true,
                             fields: {
-                                pulse_survey_status: "ACCEPTED",
+                                pulse_survey: "ACCEPTED",
                             }
                         })
                     );
@@ -118,7 +118,7 @@ describe("ussd_pulse_survey app", function() {
                             urn: "whatsapp:27123456789",
                             exists: true,
                             fields: {
-                                pulse_survey_status: "COMPLETED",
+                                pulse_survey: "COMPLETED",
                             }
                         })
                     );
@@ -149,7 +149,7 @@ describe("ussd_pulse_survey app", function() {
                             urn: "whatsapp:27123456789",
                             exists: true,
                             fields: {
-                                pulse_survey_status: "",
+                                pulse_survey: "",
                             }
                         })
                     );
@@ -309,7 +309,7 @@ describe("ussd_pulse_survey app", function() {
                     wa_pulse_survey_started: "Yes",
                     contact: {
                         fields: {
-                            pulse_survey_status: "SELECTED"
+                            pulse_survey: "SELECTED"
                         }
                     }
                 }).setup(function(api) {


### PR DESCRIPTION
This pull request just renames the pulse survey field so it's consistent with the main rapidpro flow.